### PR TITLE
fix(tiktok): Prevent false error message on successful download

### DIFF
--- a/plugins/tiktok-auto.js
+++ b/plugins/tiktok-auto.js
@@ -63,7 +63,13 @@ const tiktokAutoDownloader = {
                 },
                 { quoted: msg }
             );
-             await sock.sendMessage(msg.key.remoteJid, { react: { text: '✅', key: msg.key } });
+
+            // Send success reaction in its own try-catch to prevent it from triggering the main error block.
+            try {
+                await sock.sendMessage(msg.key.remoteJid, { react: { text: '✅', key: msg.key } });
+            } catch (reactError) {
+                console.error("Error sending success reaction:", reactError);
+            }
 
         } catch (error) {
             console.error("Error in TikTok auto-downloader:", error);


### PR DESCRIPTION
Wraps the success reaction in `plugins/tiktok-auto.js` in its own try-catch block. This prevents a non-critical failure (like failing to send a reaction) from triggering the main error handling logic, which was causing the bot to send an error message to the user even after a successful video download.