### PR TITLE
feat(play): Overhaul play command for multi-functionality

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -90,7 +90,8 @@ export async function handler(m, isSubBot = false) {
       // Ejecución
       try {
         await new Promise(resolve => setTimeout(resolve, RESPONSE_DELAY_MS));
-        await command.execute({ sock, msg, args, commands, config, testCache, isOwner });
+        // Pasamos 'commandName' para que los comandos puedan saber con qué alias fueron llamados.
+        await command.execute({ sock, msg, args, commands, config, testCache, isOwner, commandName });
         cooldowns.set(senderId, Date.now());
       } catch (error) {
         console.error(`Error en comando ${commandName}:`, error);


### PR DESCRIPTION
- Replaces the `plugins/play.js` file with a new, more powerful implementation that can download both audio and video.
- The command's behavior now depends on the alias used to call it (e.g., `play` for audio, `play2` for video).
- Modifies `handler.js` to pass `commandName` to the `execute` function, enabling the new alias-based logic.
- Improves user feedback with detailed info cards and more specific error messages.