### PR TITLE
feat(play): Overhaul play command with new helpers and multi-API support

### DIFF
--- a/lib/youtubedl.js
+++ b/lib/youtubedl.js
@@ -1,0 +1,313 @@
+import axios from 'axios';
+import crypto from 'crypto';
+
+const ogmp3 = {
+  api: {
+    base: "https://api3.apiapi.lat",
+    endpoints: {
+      a: "https://api5.apiapi.lat",
+      b: "https://api.apiapi.lat",
+      c: "https://api3.apiapi.lat"
+    }
+  },
+
+  headers: {
+    'authority': 'api.apiapi.lat',
+    'content-type': 'application/json',
+    'origin': 'https://ogmp3.lat',
+    'referer': 'https://ogmp3.lat/',
+    'user-agent': 'Postify/1.0.0'
+  },
+
+  formats: {
+    video: ['240', '360', '480', '720', '1080'],
+    audio: ['64', '96', '128', '192', '256', '320']
+  },
+
+  default_fmt: {
+    video: '720',
+    audio: '320'
+  },
+
+  restrictedTimezones: new Set(["-330", "-420", "-480", "-540"]),
+
+  utils: {
+    hash: () => {
+      // Use Node.js crypto.randomBytes to generate a secure random hex string.
+      return crypto.randomBytes(16).toString('hex');
+    },
+
+    encoded: (str) => {
+      let result = "";
+      for (let i = 0; i < str.length; i++) {
+        result += String.fromCharCode(str.charCodeAt(i) ^ 1);
+      }
+      return result;
+    },
+
+    enc_url: (url, separator = ",") => {
+      const codes = [];
+      for (let i = 0; i < url.length; i++) {
+        codes.push(url.charCodeAt(i));
+      }
+      return codes.join(separator).split(separator).reverse().join(separator);
+    }
+  },
+
+  isUrl: str => {
+    try {
+      const url = new URL(str);
+      const hostname = url.hostname.toLowerCase();
+      const b = [/^(.+\.)?youtube\.com$/, /^(.+\.)?youtube-nocookie\.com$/, /^youtu\.be$/];
+      return b.some(a => a.test(hostname)) && !url.searchParams.has("playlist");
+    } catch (_) {
+      return false;
+    }
+  },
+
+  youtube: url => {
+    if (!url) return null;
+    const b = [
+      /youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/v\/([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+      /youtu\.be\/([a-zA-Z0-9_-]{11})/
+    ];
+    for (let a of b) {
+      if (a.test(url)) return url.match(a)[1];
+    }
+    return null;
+  },
+
+  request: async (endpoint, data = {}, method = 'post') => {
+    try {
+      const ae = Object.values(ogmp3.api.endpoints);
+      const be = ae[Math.floor(Math.random() * ae.length)];
+
+      const fe = endpoint.startsWith('http') ? endpoint : `${be}${endpoint}`;
+
+      const { data: response } = await axios({
+        method,
+        url: fe,
+        data: method === 'post' ? data : undefined,
+        headers: ogmp3.headers
+      });
+      return {
+        status: true,
+        code: 200,
+        data: response
+      };
+    } catch (error) {
+      return {
+        status: false,
+        code: error.response?.status || 500,
+        error: error.message
+      };
+    }
+  },
+
+  async checkStatus(id) {
+    try {
+      const c = this.utils.hash();
+      const d = this.utils.hash();
+      const endpoint = `/${c}/status/${this.utils.encoded(id)}/${d}/`;
+
+      const response = await this.request(endpoint, {
+        data: id
+      });
+
+      return response;
+    } catch (error) {
+      return {
+        status: false,
+        code: 500,
+        error: error.message
+      };
+    }
+  },
+
+  async checkProgress(data) {
+    try {
+      let attempts = 0;
+      let maxAttempts = 300;
+
+      while (attempts < maxAttempts) {
+        attempts++;
+
+        const res = await this.checkStatus(data.i);
+        if (!res.status) {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          continue;
+        }
+
+        const stat = res.data;
+        if (stat.s === "C") {
+          return stat;
+        }
+
+        if (stat.s === "P") {
+          await new Promise(resolve => setTimeout(resolve, 2000));
+          continue;
+        }
+
+        return null;
+      }
+
+      return null;
+    } catch (error) {
+      return null;
+    }
+  },
+
+  download: async (link, format, type = 'video') => {
+    if (!link) {
+      return {
+        status: false,
+        code: 400,
+        error: "¿Que es lo que descarga? ingresa en link idiota"
+      };
+    }
+
+    if (!ogmp3.isUrl(link)) {
+      return {
+        status: false,
+        code: 400,
+        error: "Ese link es invalido pon en link de un video de youtube valido idiotas 🗿"
+      };
+    }
+
+    if (type !== 'video' && type !== 'audio') {
+      return {
+        status: false,
+        code: 400,
+        error: "Elejir video o audio?"
+      };
+    }
+
+    if (!format) {
+      format = type === 'audio' ? ogmp3.default_fmt.audio : ogmp3.default_fmt.video;
+    }
+
+    const valid_fmt = type === 'audio' ? ogmp3.formats.audio : ogmp3.formats.video;
+    if (!valid_fmt.includes(format)) {
+      return {
+        status: false,
+        code: 400,
+        error: `Formato ${format} no es valido para ${type} pero puedes elegir unos de estos: ${valid_fmt.join(', ')}`
+      };
+    }
+
+    const id = ogmp3.youtube(link);
+    if (!id) {
+      return {
+        status: false,
+        code: 400,
+        error: "Donde pito esta la ID del video? no puedo extraerlo hdp"
+      };
+    }
+
+    try {
+      let retries = 0;
+      const maxRetries = 20;
+
+      while (retries < maxRetries) {
+        retries++;
+        const c = ogmp3.utils.hash();
+        const d = ogmp3.utils.hash();
+        const req = {
+          data: ogmp3.utils.encoded(link),
+          format: type === 'audio' ? "0" : "1",
+          referer: "https://ogmp3.cc",
+          mp3Quality: type === 'audio' ? format : null,
+          mp4Quality: type === 'video' ? format : null,
+          userTimeZone: new Date().getTimezoneOffset().toString()
+        };
+
+        const resx = await ogmp3.request(
+          `/${c}/init/${ogmp3.utils.enc_url(link)}/${d}/`,
+          req
+        );
+
+        if (!resx.status) {
+          if (retries === maxRetries) return resx;
+          continue;
+        }
+
+        const data = resx.data;
+        if (data.le) {
+          return {
+            status: false,
+            code: 400,
+            error: "La duración del video es demasiado larga, amigo. El máximo es de 3 horas, no puedes superar eso, ¿entendido? 👍🏻"
+          };
+        }
+
+        if (data.i === "blacklisted") {
+          const limit = ogmp3.restrictedTimezones.has(new Date().getTimezoneOffset().toString()) ? 5 : 100;
+          return {
+            status: false,
+            code: 429,
+            error: `Limite de descargas diarias (${limit}) alcanzados, intente de nuevo mas tardes.`
+          };
+        }
+
+        if (data.e || data.i === "invalid") {
+          return {
+            status: false,
+            code: 400,
+            error: "El video no existe, idiota. No sé si fue eliminado o si YouTube lo restringió... no tengo idea 🤷🏻"
+          };
+        }
+
+        if (data.s === "C") {
+          return {
+            status: true,
+            code: 200,
+            result: {
+              title: data.t || "Kagak tau",
+              type: type,
+              format: format,
+              thumbnail: `https://i.ytimg.com/vi/${id}/maxresdefault.jpg`,
+              download: `${ogmp3.api.base}/${ogmp3.utils.hash()}/download/${ogmp3.utils.encoded(data.i)}/${ogmp3.utils.hash()}/`,
+              id: id,
+              quality: format
+            }
+          };
+        }
+
+        const prod = await ogmp3.checkProgress(data);
+        if (prod && prod.s === "C") {
+          return {
+            status: true,
+            code: 200,
+            result: {
+              title: prod.t || "Kagak tau",
+              type: type,
+              format: format,
+              thumbnail: `https://i.ytimg.com/vi/${id}/maxresdefault.jpg`,
+              download: `${ogmp3.api.base}/${ogmp3.utils.hash()}/download/${ogmp3.utils.encoded(prod.i)}/${ogmp3.utils.hash()}/`,
+              id: id,
+              quality: format
+            }
+          };
+        }
+      }
+
+      return {
+        status: false,
+        code: 500,
+        error: "Estoy exhausto, idiota... Ya intenté hacer la solicitud varias veces y sigue sin funcionar, así que dejaré la solicitud para más tarde, ¡hasta luego! 😂"
+      };
+
+    } catch (error) {
+      return {
+        status: false,
+        code: 500,
+        error: error.message
+      };
+    }
+  }
+};
+
+export { ogmp3 };

--- a/lib/yt-savetube.js
+++ b/lib/yt-savetube.js
@@ -1,0 +1,182 @@
+import axios from 'axios';
+import crypto from 'crypto';
+
+const savetube = {
+  api: {
+    base: "https://media.savetube.me/api",
+    cdn: "/random-cdn",
+    info: "/v2/info",
+    download: "/download"
+  },
+  headers: {
+    'accept': '*/*',
+    'content-type': 'application/json',
+    'origin': 'https://yt.savetube.me',
+    'referer': 'https://yt.savetube.me/',
+    'user-agent': 'Postify/1.0.0'
+  },
+  formats: ['144', '240', '360', '480', '720', '1080', 'mp3'],
+
+  crypto: {
+    hexToBuffer: (hexString) => {
+      const matches = hexString.match(/.{1,2}/g);
+      return Buffer.from(matches.join(''), 'hex');
+    },
+
+    decrypt: async (enc) => {
+      try {
+        const secretKey = 'C5D58EF67A7584E4A29F6C35BBC4EB12';
+        const data = Buffer.from(enc, 'base64');
+        const iv = data.slice(0, 16);
+        const content = data.slice(16);
+        const key = savetube.crypto.hexToBuffer(secretKey);
+
+        const decipher = crypto.createDecipheriv('aes-128-cbc', key, iv);
+        let decrypted = decipher.update(content);
+        decrypted = Buffer.concat([decrypted, decipher.final()]);
+
+        return JSON.parse(decrypted.toString());
+      } catch (error) {
+        throw new Error(`${error.message}`);
+      }
+    }
+  },
+
+  isUrl: str => {
+    try {
+      new URL(str);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  },
+
+  youtube: url => {
+    if (!url) return null;
+    const a = [
+      /youtube\.com\/watch\?v=([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/embed\/([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/v\/([a-zA-Z0-9_-]{11})/,
+      /youtube\.com\/shorts\/([a-zA-Z0-9_-]{11})/,
+      /youtu\.be\/([a-zA-Z0-9_-]{11})/
+    ];
+    for (let b of a) {
+      if (b.test(url)) return url.match(b)[1];
+    }
+    return null;
+  },
+
+  request: async (endpoint, data = {}, method = 'post') => {
+    try {
+      const { data: response } = await axios({
+        method,
+        url: `${endpoint.startsWith('http') ? '' : savetube.api.base}${endpoint}`,
+        data: method === 'post' ? data : undefined,
+        params: method === 'get' ? data : undefined,
+        headers: savetube.headers
+      });
+      return {
+        status: true,
+        code: 200,
+        data: response
+      };
+    } catch (error) {
+      return {
+        status: false,
+        code: error.response?.status || 500,
+        error: error.message
+      };
+    }
+  },
+
+  getCDN: async () => {
+    const response = await savetube.request(savetube.api.cdn, {}, 'get');
+    if (!response.status) return response;
+    return {
+      status: true,
+      code: 200,
+      data: response.data.cdn
+    };
+  },
+
+  download: async (link, format) => {
+    if (!link) {
+      return {
+        status: false,
+        code: 400,
+        error: "[ ❌ ] ¿Dónde está el link? No puedes descargar sin link "
+      };
+    }
+
+    if (!savetube.isUrl(link)) {
+      return {
+        status: false,
+        code: 400,
+        error: "[ ❌ ] ¿Qué link pusiste? 🗿 Deberías poner un link de YouTube, si vas a descargar de ahí 👍🏻"
+      };
+    }
+
+    if (!format || !savetube.formats.includes(format)) {
+      return {
+        status: false,
+        code: 400,
+        error: "*[ ❌ ] El formato no está disponible, elige uno de los que ya están disponibles, no busques lo que no hay 🗿*",
+        available_fmt: savetube.formats
+      };
+    }
+
+    const id = savetube.youtube(link);
+    if (!id) {
+      return {
+        status: false,
+        code: 400,
+        error: "*[ ❌ ] No se puede extraer el enlace de YouTube, asegúrate de que el enlace sea el correcto para evitar esto nuevamente 😂*"
+      };
+    }
+
+    try {
+      const cdnx = await savetube.getCDN();
+      if (!cdnx.status) return cdnx;
+      const cdn = cdnx.data;
+
+      const result = await savetube.request(`https://${cdn}${savetube.api.info}`, {
+        url: `https://www.youtube.com/watch?v=${id}`
+      });
+      if (!result.status) return result;
+      const decrypted = await savetube.crypto.decrypt(result.data.data);
+
+      const dl = await savetube.request(`https://${cdn}${savetube.api.download}`, {
+        id: id,
+        downloadType: format === 'mp3' ? 'audio' : 'video',
+        quality: format === 'mp3' ? '128' : format,
+        key: decrypted.key
+      });
+
+      return {
+        status: true,
+        code: 200,
+        result: {
+          title: decrypted.title || "Sin tittle",
+          type: format === 'mp3' ? 'audio' : 'video',
+          format: format,
+          thumbnail: decrypted.thumbnail || `https://i.ytimg.com/vi/${id}/maxresdefault.jpg`,
+          download: dl.data.data.downloadUrl,
+          id: id,
+          key: decrypted.key,
+          duration: decrypted.duration,
+          quality: format === 'mp3' ? '128' : format,
+          downloaded: dl.data.data.downloaded || false
+        }
+      };
+
+    } catch (error) {
+      return {
+        status: false,
+        code: 500,
+        error: error.message
+      };
+    }
+  }
+};
+
+export { savetube };

--- a/plugins/play.js
+++ b/plugins/play.js
@@ -1,102 +1,127 @@
-import fetch from "node-fetch";
+import fetch from 'node-fetch';
 import yts from 'yt-search';
+import axios from 'axios';
+import { savetube } from '../lib/yt-savetube.js';
+import { ogmp3 } from '../lib/youtubedl.js';
 import config from '../config.js';
 
-// Helper function to format large numbers for display
-function formatViews(views) {
-  if (views === undefined || views === null) return "No disponible";
-  if (views >= 1_000_000_000) return `${(views / 1_000_000_000).toFixed(1)}B`;
-  if (views >= 1_000_000) return `${(views / 1_000_000).toFixed(1)}M`;
-  if (views >= 1_000) return `${(views / 1_000).toFixed(1)}k`;
-  return views.toString();
+const LimitAud = 725 * 1024 * 1024; // 725MB
+const LimitVid = 425 * 1024 * 1024; // 425MB
+const userRequests = new Set();
+
+// Helper function to get the size of a remote file
+async function getFileSize(url) {
+  try {
+    const response = await fetch(url, { method: 'HEAD' });
+    return parseInt(response.headers.get('content-length') || 0);
+  } catch {
+    return 0; // If HEAD request fails, assume 0
+  }
+}
+
+// Helper function to format duration in seconds to a readable string
+function secondString(seconds) {
+    seconds = Number(seconds);
+    const d = Math.floor(seconds / (3600 * 24));
+    const h = Math.floor((seconds % (3600 * 24)) / 3600);
+    const m = Math.floor((seconds % 3600) / 60);
+    const s = Math.floor(seconds % 60);
+    const parts = [];
+    if (d > 0) parts.push(d + (d === 1 ? ' día' : ' días'));
+    if (h > 0) parts.push(h + (h === 1 ? ' hora' : ' horas'));
+    if (m > 0) parts.push(m + (m === 1 ? ' minuto' : ' minutos'));
+    if (s > 0) parts.push(s + (s === 1 ? ' segundo' : ' segundos'));
+    return parts.join(', ');
 }
 
 const playCommand = {
   name: "play",
   category: "descargas",
-  description: "Busca y descarga audio o video de YouTube.",
-  aliases: ['yta', 'ytmp3', 'play2', 'ytv', 'ytmp4', 'playaudio', 'mp4'],
+  description: "Busca y descarga audio o video de YouTube con múltiples opciones y APIs.",
+  aliases: ['musica', 'play2', 'video', 'play3', 'playdoc', 'play4', 'playdoc2'],
 
   async execute({ sock, msg, args, commandName }) {
     const text = args.join(' ');
     if (!text.trim()) {
-      return sock.sendMessage(msg.key.remoteJid, { text: `❀ Por favor, ingresa el nombre de la música a descargar.` }, { quoted: msg });
+      return sock.sendMessage(msg.key.remoteJid, { text: `*🤔 ¿Qué estás buscando?*\nIngresa el nombre o enlace de la canción.\n\n*Ejemplo:*\n.play Morat` }, { quoted: msg });
     }
+
+    if (userRequests.has(msg.sender)) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `⏳ Oye, calma. Ya tienes una descarga en proceso. Espera a que termine.` }, { quoted: msg });
+    }
+
+    userRequests.add(msg.sender);
 
     try {
       await sock.sendMessage(msg.key.remoteJid, { react: { text: '🔍', key: msg.key } });
 
-      const youtubeRegexID = /(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/))([a-zA-Z0-9_-]{11})/;
-      const videoIdMatch = text.match(youtubeRegexID);
-      const searchQuery = videoIdMatch ? `https://youtu.be/${videoIdMatch[1]}` : text;
-
-      const searchResults = await yts(searchQuery);
+      const searchResults = await yts(text);
       const video = searchResults.videos[0];
 
       if (!video) {
-        return sock.sendMessage(msg.key.remoteJid, { text: '✧ No se encontraron resultados para tu búsqueda.' }, { quoted: msg });
+        throw new Error('No se encontraron resultados para tu búsqueda.');
       }
 
-      const { title, thumbnail, timestamp, views, ago, url, author } = video;
-      const formattedViews = formatViews(views);
-      const channel = author ? author.name : 'Desconocido';
+      const tipoDescarga = ['play', 'musica', 'play3', 'playdoc'].includes(commandName) ? 'audio' : 'video';
 
-      const infoMessage = `「✦」Descargando *<${title || 'Desconocido'}>*\n\n` +
-                          `> 📺 Canal ✦ *${channel}*\n` +
-                          `> 👀 Vistas ✦ *${formattedViews || 'Desconocido'}*\n` +
-                          `> ⏳ Duración ✦ *${timestamp || 'Desconocido'}*\n` +
-                          `> 📆 Publicado ✦ *${ago || 'Desconocido'}*\n` +
-                          `> 🖇️ Link ✦ ${url}`;
+      await sock.sendMessage(msg.key.remoteJid, { text: `*${video.title}*\n\n*⇄ㅤ     ◁   ㅤ  ❚❚ㅤ     ▷ㅤ     ↻*\n\n*⏰ Duración:* ${secondString(video.duration.seconds)}\n*👉🏻 Aguarde un momento en lo que envío su ${tipoDescarga}*`}, { quoted: msg });
 
-      await sock.sendMessage(msg.key.remoteJid, {
-        image: { url: thumbnail },
-        caption: infoMessage,
-        contextInfo: {
-          externalAdReply: {
-            title: config.botName, // Adaptado para usar config
-            body: `By: ${config.ownerName}`, // Adaptado para usar config
-            mediaType: 1,
-            thumbnail: await (await fetch(thumbnail)).buffer(),
-            mediaUrl: url,
-            sourceUrl: url,
-            renderLargerThumbnail: true,
+      // --- Lógica de descarga ---
+      const isAudio = ['play', 'musica', 'play3', 'playdoc'].includes(commandName);
+      const isDocument = ['play3', 'playdoc', 'play4', 'playdoc2'].includes(commandName);
+
+      const audioApis = [
+        () => savetube.download(video.url, 'mp3'),
+        () => ogmp3.download(video.url, '320', 'audio')
+      ];
+      const videoApis = [
+        () => savetube.download(video.url, '720'),
+        () => ogmp3.download(video.url, '720', 'video')
+      ];
+
+      let downloadResult = null;
+      for (const apiCall of (isAudio ? audioApis : videoApis)) {
+        try {
+          const result = await apiCall();
+          if (result && result.status && result.result.download) {
+            downloadResult = result.result;
+            break;
           }
-        }
-      }, { quoted: msg });
-
-      if (['play', 'yta', 'ytmp3', 'playaudio'].includes(commandName)) {
-        try {
-          await sock.sendMessage(msg.key.remoteJid, { react: { text: '🎵', key: msg.key } });
-          const apiRes = await fetch(`https://api.vreden.my.id/api/ytmp3?url=${url}`);
-          const apiJson = await apiRes.json();
-          const downloadUrl = apiJson.result.download.url;
-
-          if (!downloadUrl) throw new Error('El enlace de audio no se generó correctamente.');
-
-          await sock.sendMessage(msg.key.remoteJid, { audio: { url: downloadUrl }, fileName: `${title}.mp3`, mimetype: 'audio/mpeg' }, { quoted: msg });
         } catch (e) {
-          console.error("Error al descargar audio:", e);
-          return sock.sendMessage(msg.key.remoteJid, { text: '✦ No se pudo enviar el audio. El archivo puede ser demasiado pesado o la API falló.' }, { quoted: msg });
-        }
-      } else if (['play2', 'ytv', 'ytmp4', 'mp4'].includes(commandName)) {
-        try {
-          await sock.sendMessage(msg.key.remoteJid, { react: { text: '📹', key: msg.key } });
-          const apiRes = await fetch(`https://api.neoxr.eu/api/youtube?url=${url}&type=video&quality=480p&apikey=GataDios`);
-          const apiJson = await apiRes.json();
-          const downloadUrl = apiJson.data.url;
-
-          if (!downloadUrl) throw new Error('No se pudo generar el enlace de video.');
-
-          await sock.sendMessage(msg.key.remoteJid, { video: { url: downloadUrl }, caption: title }, { quoted: msg });
-        } catch (e) {
-          console.error("Error al descargar video:", e);
-          return sock.sendMessage(msg.key.remoteJid, { text: '✦ No se pudo enviar el video. El archivo puede ser demasiado pesado o la API falló.' }, { quoted: msg });
+          console.error(`Fallo de API en Play: ${e.message}`);
+          continue;
         }
       }
+
+      if (!downloadResult) {
+        throw new Error('Todas las APIs de descarga fallaron.');
+      }
+
+      const fileSize = await getFileSize(downloadResult.download);
+      const sizeLimit = isAudio ? LimitAud : LimitVid;
+
+      if (fileSize > sizeLimit || isDocument) {
+        await sock.sendMessage(msg.key.remoteJid, {
+          document: { url: downloadResult.download },
+          mimetype: isAudio ? 'audio/mpeg' : 'video/mp4',
+          fileName: `${downloadResult.title}.${isAudio ? 'mp3' : 'mp4'}`,
+          caption: `✅ *Descarga como documento*\n*Título:* ${downloadResult.title}`
+        }, { quoted: msg });
+      } else {
+        if (isAudio) {
+          await sock.sendMessage(msg.key.remoteJid, { audio: { url: downloadResult.download }, mimetype: 'audio/mpeg' }, { quoted: msg });
+        } else {
+          await sock.sendMessage(msg.key.remoteJid, { video: { url: downloadResult.download }, caption: `✅ *${downloadResult.title}*` }, { quoted: msg });
+        }
+      }
+      await sock.sendMessage(msg.key.remoteJid, { react: { text: '✅', key: msg.key } });
 
     } catch (error) {
       console.error("Error en el comando play:", error);
-      return sock.sendMessage(msg.key.remoteJid, { text: `✦ Ocurrió un error: ${error.message}` }, { quoted: msg });
+      await sock.sendMessage(msg.key.remoteJid, { react: { text: '❌', key: msg.key } });
+      await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error: ${error.message}` }, { quoted: msg });
+    } finally {
+      userRequests.delete(msg.sender);
     }
   }
 };


### PR DESCRIPTION
- Adds new helper libraries `lib/youtubedl.js` and `lib/yt-savetube.js` to handle YouTube downloads.
- Replaces `plugins/play.js` with a new, more powerful version that utilizes a multi-API fallback system for increased reliability.
- The command now supports various download types (audio, video, document) based on the alias used.
- Implements a user-specific request lock to prevent spam.
- Fixes critical bugs in the provided helper code to ensure stability.