### PR TITLE
feat(artista): Add command for artist downloads with persistent queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -426,16 +426,21 @@ function runHourlyMaintenance() {
   });
 }
 
+import { startArtistQueueWorker } from './plugins/artista.js';
+
 // --- INICIO DEL BOT ---
 (async () => {
   await loadCommands();
   const sock = await connectToWhatsApp();
 
-  // Iniciar la tarea de mantenimiento una vez que el bot esté conectado.
   if (sock) {
+    // Iniciar la tarea de mantenimiento una vez que el bot esté conectado.
     console.log('[Scheduler] Tarea de mantenimiento por hora configurada.');
-    // Se ejecutará cada hora (3600000 ms)
-    setInterval(runHourlyMaintenance, 3600000);
+    setInterval(runHourlyMaintenance, 3600000); // Se ejecutará cada hora
+
+    // Iniciar el worker de la cola de descargas de artistas.
+    console.log('[Queue] Iniciando el worker de la cola de artistas...');
+    startArtistQueueWorker(sock);
   }
 })();
 

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import path from 'path';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const queueFilePath = path.join(__dirname, '../queue.json');
+
+// Ensure the queue file exists
+function initializeQueueFile() {
+    if (!fs.existsSync(queueFilePath)) {
+        fs.writeFileSync(queueFilePath, JSON.stringify([]), 'utf-8');
+    }
+}
+
+// Read the entire queue from the file
+function readQueue() {
+    try {
+        const data = fs.readFileSync(queueFilePath, 'utf-8');
+        return JSON.parse(data);
+    } catch (error) {
+        console.error("Error reading queue file, returning empty queue:", error);
+        return [];
+    }
+}
+
+// Write the entire queue to the file
+function writeQueue(queue) {
+    try {
+        fs.writeFileSync(queueFilePath, JSON.stringify(queue, null, 2), 'utf-8');
+    } catch (error) {
+        console.error("Error writing to queue file:", error);
+    }
+}
+
+// Add a new request to the end of the queue
+function addToQueue(request) {
+    const queue = readQueue();
+    queue.push(request);
+    writeQueue(queue);
+}
+
+// Get the next request from the front of the queue and remove it
+function takeFromQueue() {
+    const queue = readQueue();
+    if (queue.length === 0) {
+        return null;
+    }
+    const nextRequest = queue.shift(); // Remove the first item
+    writeQueue(queue);
+    return nextRequest;
+}
+
+// Peek at the first item in the queue without removing it
+function peekQueue() {
+    const queue = readQueue();
+    return queue.length > 0 ? queue[0] : null;
+}
+
+initializeQueueFile();
+
+export {
+    readQueue,
+    addToQueue,
+    takeFromQueue,
+    peekQueue
+};

--- a/plugins/artista.js
+++ b/plugins/artista.js
@@ -1,0 +1,139 @@
+import yts from 'yt-search';
+import { addToQueue, takeFromQueue, readQueue } from '../lib/queue.js';
+import { savetube } from '../lib/yt-savetube.js';
+import { ogmp3 } from '../lib/youtubedl.js';
+
+let isWorkerRunning = false;
+let sockInstance = null; // This will hold the bot's socket connection
+
+// The main worker function that processes one request from the queue
+async function processQueue() {
+    if (isWorkerRunning || !sockInstance) {
+        return; // Worker is already busy or not initialized
+    }
+
+    const request = takeFromQueue();
+    if (!request) {
+        console.log("[Artista Worker] Queue is empty. Worker is idle.");
+        isWorkerRunning = false;
+        return;
+    }
+
+    isWorkerRunning = true;
+    const { chatId, artist, type, originalMessageKey } = request;
+
+    try {
+        await sockInstance.sendMessage(chatId, { text: `▶️ *Comenzando tu solicitud para "${artist}"!*\nBuscando las 50 canciones principales...` }, { quoted: { key: originalMessageKey } });
+
+        const searchResults = await yts({ query: `${artist} top 50 songs`, pages: 3 });
+        const videos = searchResults.videos.slice(0, 50);
+
+        if (videos.length === 0) {
+            throw new Error(`No se encontraron canciones para "${artist}".`);
+        }
+
+        await sockInstance.sendMessage(chatId, { text: `✅ *¡Se encontraron ${videos.length} canciones!*\nComenzando la descarga. Esto puede tardar varios minutos...` }, { quoted: { key: originalMessageKey } });
+
+        for (let i = 0; i < videos.length; i++) {
+            const video = videos[i];
+            console.log(`[Artista Worker] Descargando [${i + 1}/${videos.length}]: ${video.title}`);
+
+            const isAudio = type === 'audio';
+            const apis = isAudio
+                ? [() => savetube.download(video.url, 'mp3'), () => ogmp3.download(video.url, '320', 'audio')]
+                : [() => savetube.download(video.url, '720'), () => ogmp3.download(video.url, '720', 'video')];
+
+            let downloadResult = null;
+            for (const apiCall of apis) {
+                try {
+                    const result = await apiCall();
+                    if (result && result.status && result.result.download) {
+                        downloadResult = result.result;
+                        break;
+                    }
+                } catch (e) {
+                    // This API failed, try the next one
+                    continue;
+                }
+            }
+
+            if (downloadResult && downloadResult.download) {
+                try {
+                    if (isAudio) {
+                        await sockInstance.sendMessage(chatId, { audio: { url: downloadResult.download }, mimetype: 'audio/mpeg' });
+                    } else {
+                        await sockInstance.sendMessage(chatId, { video: { url: downloadResult.download }, caption: video.title });
+                    }
+                } catch (sendError) {
+                    console.error(`[Artista Worker] Failed to send file for "${video.title}": ${sendError.message}`);
+                }
+            }
+        }
+
+        await sockInstance.sendMessage(chatId, { text: `✅ *¡Descarga completada!*\nSe enviaron ${videos.length} canciones de *${artist}*.` }, { quoted: { key: originalMessageKey } });
+
+    } catch (error) {
+        console.error("[Artista Worker] A critical error occurred:", error);
+        await sockInstance.sendMessage(chatId, { text: `❌ *Ocurrió un error procesando tu solicitud para "${artist}"*.\nMotivo: ${error.message}` }, { quoted: { key: originalMessageKey } });
+    } finally {
+        isWorkerRunning = false;
+        // Automatically check for the next item in the queue
+        setTimeout(processQueue, 2000); // Small delay to prevent tight loops
+    }
+}
+
+// This function will be imported and called from index.js after the bot connects
+export function startArtistQueueWorker(sock) {
+    if (!sockInstance) {
+        sockInstance = sock;
+    }
+    const queue = readQueue();
+    if (queue.length > 0) {
+        console.log(`[Artista Worker] Found ${queue.length} items in queue on startup. Starting worker.`);
+        processQueue();
+    } else {
+        console.log("[Artista Worker] Queue is empty on startup. Worker is ready.");
+    }
+}
+
+// The user-facing command object
+const artistaCommand = {
+  name: "artista",
+  category: "descargas",
+  description: "Descarga las 50 canciones más populares de un artista. Usa artista2 para video.",
+  aliases: ["artista2"],
+
+  async execute({ sock, msg, args, commandName }) {
+    const artist = args.join(' ');
+    if (!artist) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `Por favor, ingresa el nombre de un artista.\n\n*Ejemplo:*\n.artista Morat` }, { quoted: msg });
+    }
+
+    const type = commandName === 'artista' ? 'audio' : 'video';
+    const queue = readQueue();
+
+    const request = {
+      chatId: msg.key.remoteJid,
+      artist: artist,
+      type: type,
+      originalMessageKey: msg.key // Store key for quoting replies
+    };
+
+    addToQueue(request);
+
+    const position = queue.length + 1;
+    let replyText = `✅ *¡Tu solicitud para "${artist}" (${type}) ha sido agregada a la cola!*`;
+    if (isWorkerRunning) {
+        replyText += `\nHay ${position - 1} solicitud(es) antes que la tuya. Por favor, espera tu turno.`;
+    }
+
+    await sock.sendMessage(msg.key.remoteJid, { text: replyText }, { quoted: msg });
+
+    // Start the worker if it's not already running
+    if (!isWorkerRunning) {
+        startArtistQueueWorker(sock);
+    }
+  }
+};
+
+export default artistaCommand;


### PR DESCRIPTION
- Adds `lib/queue.js` to manage a file-based persistent queue (`queue.json`).
- Adds `plugins/artista.js` which contains the `artista` and `artista2` commands.
- These commands add a request to the queue to download the top 50 songs from an artist as audio or video.
- A worker function in `artista.js` processes the queue sequentially, using the robust multi-API logic from the `play` command's helpers.
- Modifies `index.js` to initialize the queue worker on startup, ensuring persistence across restarts.