### PR TITLE
fix(unregister): Fix startup crash and close daily limit loophole

### DIFF
--- a/lib/usage.js
+++ b/lib/usage.js
@@ -90,3 +90,15 @@ export function incrementCommandUsage(userId, commandName) {
 
     writeUsageDb(usageDb);
 }
+
+/**
+ * Deletes all usage data for a specific user.
+ * @param {string} userId The user's ID.
+ */
+export function deleteUserUsage(userId) {
+    const usageDb = readUsageDb();
+    if (usageDb[userId]) {
+        delete usageDb[userId];
+        writeUsageDb(usageDb);
+    }
+}

--- a/plugins/unregister.js
+++ b/plugins/unregister.js
@@ -1,5 +1,5 @@
 import { readUsersDb, writeUsersDb } from '../lib/database.js';
-import { readUsageDb, writeUsageDb } from '../lib/usage.js';
+import { deleteUserUsage } from '../lib/usage.js';
 
 const unregisterCommand = {
   name: "unreg",
@@ -31,12 +31,8 @@ const unregisterCommand = {
     delete usersDb[senderId];
     writeUsersDb(usersDb);
 
-    // 2. Delete from command usage DB to close the loophole
-    const usageDb = readUsageDb();
-    if (usageDb[senderId]) {
-        delete usageDb[senderId];
-        writeUsageDb(usageDb);
-    }
+    // 2. Delete from command usage DB using the safe, exported function
+    deleteUserUsage(senderId);
 
     await sock.sendMessage(msg.key.remoteJid, { text: "✅ Has eliminado tu registro exitosamente. Todos tus datos, incluyendo el historial de uso de comandos, han sido borrados." }, { quoted: msg });
   }


### PR DESCRIPTION
- Adds and exports a new `deleteUserUsage` function in `lib/usage.js` to safely manage data deletion.
- Modifies `plugins/unregister.js` to use the new `deleteUserUsage` function.
- This resolves a fatal startup crash caused by an incorrect import.
- This also ensures that when a user unregisters, their command usage history is deleted, closing a loophole in the daily limit system.