### PR TITLE
This commit introduces two major changes: a new dashboard command for…

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -1,5 +1,5 @@
 // Este es el manejador de mensajes que usarán los sub-bots y el bot principal.
-import { commands, aliases, testCache, cooldowns } from './index.js';
+import { commands, aliases, testCache, cooldowns, commandUsage } from './index.js';
 import config from './config.js';
 import { readSettingsDb, readMaintenanceDb } from './lib/database.js';
 import print from './lib/print.js';
@@ -113,6 +113,10 @@ export async function handler(m, isSubBot = false) {
 
       // Ejecución
       try {
+        // Track command usage
+        const currentCount = commandUsage.get(command.name) || 0;
+        commandUsage.set(command.name, currentCount + 1);
+
         await new Promise(resolve => setTimeout(resolve, RESPONSE_DELAY_MS));
         // Pasamos 'commandName' para que los comandos puedan saber con qué alias fueron llamados.
         await command.execute({ sock, msg, args, commands, config, testCache, isOwner, commandName });

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ export const commands = new Map();
 export const aliases = new Map();
 export const testCache = new Map();
 export const cooldowns = new Map();
+export const commandUsage = new Map();
 
 
 

--- a/plugins/dash.js
+++ b/plugins/dash.js
@@ -1,0 +1,69 @@
+import { commandUsage } from '../index.js';
+import os from 'os';
+import osu from 'node-os-utils';
+import human from 'human-readable';
+
+const dashCommand = {
+  name: "dash",
+  category: "propietario",
+  description: "Muestra un dashboard con estadísticas del bot.",
+  aliases: ["dashboard"],
+
+  async execute({ sock, msg }) {
+    try {
+      // 1. Command Usage Stats
+      const totalCommands = Array.from(commandUsage.values()).reduce((a, b) => a + b, 0);
+      const sortedCommands = [...commandUsage.entries()].sort((a, b) => b[1] - a[1]);
+      const topCommands = sortedCommands.slice(0, 5);
+
+      let topCommandsStr = topCommands
+        .map(([name, count], index) => `  ${index + 1}. ${name}: ${count}`)
+        .join('\n');
+
+      if (sortedCommands.length === 0) {
+          topCommandsStr = "  No commands have been used yet.";
+      }
+
+      // 2. Uptime
+      const uptimeSeconds = process.uptime();
+      const d = Math.floor(uptimeSeconds / (3600 * 24));
+      const h = Math.floor(uptimeSeconds % (3600 * 24) / 3600);
+      const m = Math.floor(uptimeSeconds % 3600 / 60);
+      const s = Math.floor(uptimeSeconds % 60);
+      const uptimeStr = `${d}d ${h}h ${m}m ${s}s`;
+
+      // 3. Memory and System Info
+      const memInfo = await osu.mem.info();
+      const usedMemory = human.format.bytes(process.memoryUsage().rss);
+      const totalMemory = `${memInfo.totalMemMb} MB`;
+      const freeMemory = `${memInfo.freeMemMb} MB`;
+
+      const cpuUsage = await osu.cpu.usage();
+      const osInfo = `${os.type()} ${os.release()} (${os.arch()})`;
+      const nodeVersion = process.version;
+
+      // 4. Construct the message
+      const dashText = `*🤖 Bot Dashboard 🤖*
+
+*📊 Command Stats*
+- Total Executed: *${totalCommands}*
+- Top 5 Commands:
+${topCommandsStr}
+
+*⏱️ System Status*
+- Uptime: *${uptimeStr}*
+- OS: *${osInfo}*
+- Node.js: *${nodeVersion}*
+- CPU Usage: *${cpuUsage.toFixed(2)}%*
+- Memory (RSS): *${usedMemory}*
+- Memory (Free/Total): *${freeMemory} / ${totalMemory}*`;
+
+      await sock.sendMessage(msg.key.remoteJid, { text: dashText.trim() }, { quoted: msg });
+    } catch (e) {
+      console.error("Error in dash command:", e);
+      await sock.sendMessage(msg.key.remoteJid, { text: "❌ Error generating dashboard." }, { quoted: msg });
+    }
+  }
+};
+
+export default dashCommand;


### PR DESCRIPTION
… the bot owner and a critical fix for administrator recognition.

- **feat(dash):** Adds a new `dash` command (alias: `dashboard`) for the bot owner. This command displays a dashboard with statistics, including total commands executed, the top 5 most used commands, bot uptime, memory usage, and OS information. Command usage is tracked via a new global map.

- **fix(admin):** Fixes a bug where the bot could not correctly identify group administrators (including itself) due to WhatsApp's new LID-based JID format. A `normalizeJid` utility function has been added to sanitize JIDs before comparison, ensuring reliable admin checks. The user extraction logic in `promote` and `demote` has also been refactored into a reusable function.