### PR TITLE
This commit introduces two major changes: a new dashboard command for…

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -3,7 +3,8 @@ import { commands, aliases, testCache, cooldowns, commandUsage } from './index.j
 import config from './config.js';
 import { readSettingsDb, readMaintenanceDb } from './lib/database.js';
 import print from './lib/print.js';
-import { normalizeJid } from './lib/utils.js';
+import { getUserFromMessage } from './lib/utils.js';
+import { areJidsSameUser } from '@whiskeysockets/baileys';
 
 const COOLDOWN_SECONDS = 5;
 const RESPONSE_DELAY_MS = 2000;
@@ -75,11 +76,10 @@ export async function handler(m, isSubBot = false) {
 
       if (isGroup && (command.admin || command.botAdmin)) {
         const groupMetadata = await sock.groupMetadata(from);
-        const botJid = normalizeJid(sock.user.id);
-        const normalizedSenderId = normalizeJid(senderId);
+        const botJid = sock.user.id;
 
-        const botIsAdmin = groupMetadata.participants.some(p => normalizeJid(p.id) === botJid && (p.admin === 'admin' || p.admin === 'superadmin'));
-        const senderIsAdmin = groupMetadata.participants.some(p => normalizeJid(p.id) === normalizedSenderId && (p.admin === 'admin' || p.admin === 'superadmin'));
+        const botIsAdmin = groupMetadata.participants.some(p => areJidsSameUser(p.id, botJid) && (p.admin === 'admin' || p.admin === 'superadmin'));
+        const senderIsAdmin = groupMetadata.participants.some(p => areJidsSameUser(p.id, senderId) && (p.admin === 'admin' || p.admin === 'superadmin'));
 
         if (command.botAdmin && !botIsAdmin) {
           return sock.sendMessage(from, { text: "Necesito ser administrador del grupo para usar este comando." });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,24 +1,4 @@
 /**
- * Normalizes a JID by removing any non-digit characters before the '@'.
- * This is useful for comparing JIDs that may or may not have LIDs.
- * e.g., `12345:12@s.whatsapp.net` -> `12345@s.whatsapp.net`
- * @param {string} jid The JID to normalize.
- * @returns {string} The normalized JID.
- */
-export function normalizeJid(jid) {
-  if (!jid || typeof jid !== 'string') {
-    return jid;
-  }
-  const [user, server] = jid.split('@');
-  if (!server) {
-    return jid; // Not a valid JID format
-  }
-  // Remove LID by splitting at the colon
-  const sanitizedUser = user.split(':')[0];
-  return `${sanitizedUser}@${server}`;
-}
-
-/**
  * Extracts a user JID from a message.
  * Priority is given to mentions, then replies, then text input.
  * @param {object} msg The message object from the socket.


### PR DESCRIPTION
… the bot owner and a definitive fix for administrator recognition.

- **feat(dash):** Adds a new `dash` command (alias: `dashboard`) for the bot owner. This command displays a dashboard with statistics, including total commands executed, the top 5 most used commands, bot uptime, memory usage, and OS information. Command usage is tracked via a new global map.

- **fix(admin):** Replaces the flawed manual JID normalization with the official `areJidsSameUser` function from the Baileys library. This is the correct and robust method for comparing user JIDs and definitively resolves the bug where the bot failed to recognize admin privileges due to JID variations (e.g., LIDs). The incorrect `normalizeJid` function has been removed.

- **refactor(promote, demote):** The user identification logic in `promote.js` and `demote.js` has been refactored into a reusable `getUserFromMessage` function in `lib/utils.js`, simplifying the commands and reducing code duplication.