### PR TITLE
This commit introduces several major updates, including a new feature…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,3 +27,18 @@ export function getUserFromMessage(msg, args) {
 
   return null; // Return null if no user is found
 }
+
+/**
+ * Formats a number of bytes into a human-readable string.
+ * @param {number} bytes The number of bytes.
+ * @param {number} decimals The number of decimal places to use.
+ * @returns {string} The formatted string (e.g., "1.23 MB").
+ */
+export function formatBytes(bytes, decimals = 2) {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}

--- a/plugins/dash.js
+++ b/plugins/dash.js
@@ -1,7 +1,7 @@
 import { commandUsage } from '../index.js';
 import os from 'os';
 import osu from 'node-os-utils';
-import human from 'human-readable';
+import { formatBytes } from '../lib/utils.js';
 
 const dashCommand = {
   name: "dash",
@@ -34,9 +34,9 @@ const dashCommand = {
 
       // 3. Memory and System Info
       const memInfo = await osu.mem.info();
-      const usedMemory = human.format.bytes(process.memoryUsage().rss);
-      const totalMemory = `${memInfo.totalMemMb} MB`;
-      const freeMemory = `${memInfo.freeMemMb} MB`;
+      const usedMemory = formatBytes(process.memoryUsage().rss);
+      const totalMemory = `${memInfo.totalMemMb.toFixed(2)} MB`;
+      const freeMemory = `${memInfo.freeMemMb.toFixed(2)} MB`;
 
       const cpuUsage = await osu.cpu.usage();
       const osInfo = `${os.type()} ${os.release()} (${os.arch()})`;


### PR DESCRIPTION
…, a critical bug fix, a refactor, and logic changes based on user feedback.

- **feat(dash):** Adds a new `dash` command for the bot owner. This command displays a dashboard with statistics, including command usage, bot uptime, and system memory. It uses a new internal `formatBytes` utility to ensure reliable output.

- **fix(admin):** Replaces flawed manual JID normalization with the official `areJidsSameUser` function from the Baileys library. This is the correct and robust method for comparing user JIDs and definitively resolves the bug where the bot failed to recognize admin privileges due to JID variations (e.g., LIDs).

- **refactor(user-extraction):** The user identification logic in the `promote`, `demote`, and `kick` commands has been refactored into a reusable `getUserFromMessage` function in `lib/utils.js`, simplifying the commands and reducing code duplication.

- **chore(admin-commands):** The `botAdmin` check has been set to `false` for the `promote`, `demote`, and `kick` commands. This allows the commands to proceed as long as the user is an admin, without checking the bot's own permissions, per user request.