### PR TITLE
This is a cumulative commit that introduces several major updates, in…

### DIFF
--- a/plugins/antilink.js
+++ b/plugins/antilink.js
@@ -1,11 +1,38 @@
 import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+import { areJidsSameUser } from '@whiskeysockets/baileys';
 
-const antilinkCommand = {
+// Regex for different link types
+const linkRegexWaGroups = /chat\.whatsapp\.com\/[0-9A-Za-z]{20,24}/i;
+const linkRegexWaChannels = /whatsapp\.com\/channel\/[0-9A-Za-z]{20,24}/i;
+const linkRegexAll = /https?:\/\/\S+/i;
+
+const antilinkPlugin = {
   name: "antilink",
   category: "grupos",
-  description: "Activa o desactiva la eliminación de enlaces de invitación.",
+  description: "Activa o desactiva la eliminación de enlaces. Niveles: 1 (solo WhatsApp), 2 (todos los enlaces).",
+  aliases: ["antilinks"],
+  isAutoHandler: true, // Mark as an auto-handler to run on every message
 
-  async execute({ sock, msg, args }) {
+  /**
+   * This function handles both the command and the auto-detection logic.
+   * It differentiates based on the arguments passed by handler.js.
+   * - `body` is passed for auto-handlers.
+   * - `args` is passed for commands.
+   */
+  async execute({ sock, msg, args, body }) {
+    if (body !== undefined) {
+      // This is an auto-handler call
+      return this.handler({ sock, msg, body });
+    } else {
+      // This is a command call
+      return this.command({ sock, msg, args });
+    }
+  },
+
+  /**
+   * The command logic to configure antilink settings for a group.
+   */
+  async command({ sock, msg, args }) {
     const from = msg.key.remoteJid;
     const option = args[0]?.toLowerCase();
 
@@ -15,33 +42,89 @@ const antilinkCommand = {
 
     try {
       const metadata = await sock.groupMetadata(from);
-      const senderIsAdmin = metadata.participants.find(p => p.id === (msg.key.participant || msg.key.remoteJid))?.admin;
+      const senderIsAdmin = metadata.participants.some(p => areJidsSameUser(p.id, msg.sender) && p.admin);
       if (!senderIsAdmin) {
-        return sock.sendMessage(from, { text: "No tienes permisos de administrador." }, { quoted: msg });
+        return sock.sendMessage(from, { text: "No tienes permisos de administrador para usar este comando." }, { quoted: msg });
       }
     } catch (e) {
       return sock.sendMessage(from, { text: "Ocurrió un error al verificar tus permisos." }, { quoted: msg });
     }
 
-    if (option !== 'on' && option !== 'off') {
-      return sock.sendMessage(from, { text: "Usa `antilink on` o `antilink off`." }, { quoted: msg });
+    if (!['1', '2', 'on', 'off'].includes(option)) {
+      return sock.sendMessage(from, { text: "Usa `.antilink <nivel>`.\n\n*Niveles:*\n- `1`: Bloquear enlaces de WhatsApp.\n- `2`: Bloquear todos los enlaces.\n- `off`: Desactivar." }, { quoted: msg });
     }
 
     const settings = readSettingsDb();
     if (!settings[from]) {
-      settings[from] = {}; // Crear objeto de ajustes para el grupo si no existe
+      settings[from] = {};
     }
 
-    if (option === 'on') {
-      settings[from].antilink = true;
-      await sock.sendMessage(from, { text: "✅ El Anti-Link ha sido activado." }, { quoted: msg });
-    } else { // option === 'off'
-      settings[from].antilink = false;
-      await sock.sendMessage(from, { text: "❌ El Anti-Link ha sido desactivado." }, { quoted: msg });
+    let message;
+    if (option === '1' || option === 'on') { // 'on' for backwards compatibility
+      settings[from].antilink = 1;
+      message = "✅ Anti-Link (Nivel 1: WhatsApp) ha sido activado.";
+    } else if (option === '2') {
+      settings[from].antilink = 2;
+      message = "✅ Anti-Link (Nivel 2: Todos los enlaces) ha sido activado.";
+    } else { // 'off'
+      settings[from].antilink = 0; // Use 0 for off
+      message = "❌ El Anti-Link ha sido desactivado.";
     }
 
     writeSettingsDb(settings);
+    await sock.sendMessage(from, { text: message }, { quoted: msg });
+  },
+
+  /**
+   * The auto-handler logic that detects and acts on forbidden links.
+   */
+  async handler({ sock, msg, body }) {
+    const from = msg.key.remoteJid;
+
+    if (!from.endsWith('@g.us') || !body) return;
+
+    const settings = readSettingsDb();
+    const antilinkLevel = settings[from]?.antilink;
+
+    if (!antilinkLevel) return; // Antilink is disabled for this group (level 0 or undefined)
+
+    const metadata = await sock.groupMetadata(from);
+    const senderIsAdmin = metadata.participants.some(p => areJidsSameUser(p.id, msg.sender) && p.admin);
+    if (senderIsAdmin) return;
+
+    let isForbiddenLink = false;
+    if (antilinkLevel === 1) {
+      isForbiddenLink = linkRegexWaGroups.test(body) || linkRegexWaChannels.test(body);
+    } else if (antilinkLevel === 2) {
+      isForbiddenLink = linkRegexAll.test(body);
+    }
+
+    if (!isForbiddenLink) return;
+
+    try {
+      const groupInviteCode = await sock.groupInviteCode(from);
+      if (body.includes(groupInviteCode)) {
+        return; // It's a link to this group, so allow it.
+      }
+    } catch (e) {
+      console.warn("Antilink: Could not get group invite code. This is expected if bot is not admin.");
+    }
+
+    const userTag = `@${msg.sender.split('@')[0]}`;
+
+    try {
+      await sock.sendMessage(from, { text: `*「 ANTILINK DETECTADO 」*\n\n${userTag}, rompiste las reglas del grupo y serás eliminado.`, mentions: [msg.sender]}, { quoted: msg });
+
+      // Delete the message first
+      await sock.sendMessage(from, { delete: msg.key });
+
+      // Then kick the user
+      await sock.groupParticipantsUpdate(from, [msg.sender], 'remove');
+    } catch (e) {
+      console.error("Antilink Error:", e);
+      await sock.sendMessage(from, { text: `*「 ANTILINK DETECTADO 」*\n\n${userTag}, enviaste un link prohibido. No pude eliminarte porque me faltan permisos.`, mentions: [msg.sender]}, { quoted: msg });
+    }
   }
 };
 
-export default antilinkCommand;
+export default antilinkPlugin;


### PR DESCRIPTION
…cluding new features, critical bug fixes, and refactoring based on user feedback.

- **feat(dash):** Adds a new `dash` command for the bot owner. This command displays a dashboard with statistics, including command usage, bot uptime, and system memory. It uses a new internal `formatBytes` utility to ensure reliable output.

- **feat(antilink):** Replaces the basic antilink toggle with a powerful, unified auto-handler and command. The new system supports multiple levels of protection (WhatsApp links vs. all links), ignores admins and links to the current group, and deletes the offending message before kicking the user.

- **fix(admin):** Replaces flawed manual JID normalization with the official `areJidsSameUser` function from the Baileys library. This is the correct and robust method for comparing user JIDs and definitively resolves the bug where the bot failed to recognize admin privileges due to JID variations (e.g., LIDs).

- **refactor(user-extraction):** The user identification logic in the `promote`, `demote`, and `kick` commands has been refactored into a reusable `getUserFromMessage` function in `lib/utils.js`, simplifying the commands and reducing code duplication.

- **chore(admin-commands):** The `botAdmin` check has been set to `false` for the `promote`, `demote`, and `kick` commands. This allows the commands to proceed as long as the user is an admin, without checking the bot's own permissions, per user request.