### PR TITLE
This is a cumulative commit that introduces several major updates, in…

### DIFF
--- a/plugins/link.js
+++ b/plugins/link.js
@@ -2,36 +2,22 @@ const linkCommand = {
   name: "link",
   category: "grupos",
   description: "Obtiene el enlace de invitación del grupo.",
+  group: true, // Standard property to ensure it's only used in groups
 
-  async execute({ sock, msg, args }) {
+  async execute({ sock, msg }) {
     const from = msg.key.remoteJid;
 
-    // 1. Verificar si es un grupo
-    if (!from.endsWith('@g.us')) {
-      await sock.sendMessage(from, { text: "Este comando solo se puede usar en grupos." }, { quoted: msg });
-      return;
-    }
-
     try {
-      // 2. Obtener metadatos y verificar si el bot es admin
-      const metadata = await sock.groupMetadata(from);
-      const botJid = sock.user.id.split(':')[0] + '@s.whatsapp.net';
-      const botIsAdmin = metadata.participants.find(p => p.id === botJid)?.admin;
-
-      if (!botIsAdmin) {
-        await sock.sendMessage(from, { text: "Necesito ser administrador del grupo para obtener el enlace de invitación." }, { quoted: msg });
-        return;
-      }
-
-      // 3. Obtener y enviar el enlace
+      // Attempt to get and send the link directly.
+      // If the bot is not an admin, this will throw an error which is caught below.
       const inviteCode = await sock.groupInviteCode(from);
       const inviteLink = `https://chat.whatsapp.com/${inviteCode}`;
 
       await sock.sendMessage(from, { text: `Aquí tienes el enlace de invitación del grupo:\n\n${inviteLink}` }, { quoted: msg });
 
     } catch (error) {
-      console.error("Error en el comando link:", error);
-      await sock.sendMessage(from, { text: "Ocurrió un error al obtener el enlace del grupo." }, { quoted: msg });
+      console.error("Error in link command:", error);
+      await sock.sendMessage(from, { text: "❌ Ocurrió un error. No pude obtener el enlace, probablemente porque no soy administrador." }, { quoted: msg });
     }
   }
 };


### PR DESCRIPTION
…cluding new features, critical bug fixes, and refactoring based on user feedback.

- **feat(dash):** Adds a new `dash` command for the bot owner. This command displays a dashboard with statistics, including command usage, bot uptime, and system memory. It uses a new internal `formatBytes` utility to ensure reliable output.

- **feat(antilink):** Replaces the basic antilink toggle with a powerful, unified auto-handler and command. The new system supports multiple levels of protection (WhatsApp links vs. all links), ignores admins and links to the current group, and deletes the offending message before kicking the user.

- **fix(admin):** Replaces flawed manual JID normalization with the official `areJidsSameUser` function from the Baileys library. This is the correct and robust method for comparing user JIDs and definitively resolves the bug where the bot failed to recognize admin privileges due to JID variations (e.g., LIDs).

- **refactor(user-extraction):** The user identification logic in the `promote`, `demote`, and `kick` commands has been refactored into a reusable `getUserFromMessage` function in `lib/utils.js`, simplifying the commands and reducing code duplication.

- **chore(admin-commands):** The `botAdmin` check has been removed from the `promote`, `demote`, `kick`, and `link` commands. This allows the commands to proceed as long as the user is an admin, without checking the bot's own permissions, per user request.