### PR TITLE
This is a large cumulative commit that introduces several major updat…

### DIFF
--- a/plugins/mute-handler.js
+++ b/plugins/mute-handler.js
@@ -1,0 +1,45 @@
+import { readSettingsDb } from '../lib/database.js';
+import { areJidsSameUser } from '@whiskeysockets/baileys';
+
+const muteHandler = {
+  name: "mute-handler",
+  isAutoHandler: true,
+
+  async execute({ sock, msg }) {
+    const from = msg.key.remoteJid;
+    const senderId = msg.sender;
+
+    if (!from.endsWith('@g.us') || !senderId) return;
+
+    try {
+      const settings = readSettingsDb();
+      const mutedUsers = settings[from]?.mutedUsers;
+
+      if (!mutedUsers || mutedUsers.length === 0) {
+        return; // No users are muted in this group
+      }
+
+      const isMuted = mutedUsers.some(mutedJid => areJidsSameUser(mutedJid, senderId));
+
+      if (isMuted) {
+        // We can add a check here to ensure we don't delete messages from admins, as a safeguard
+        const metadata = await sock.groupMetadata(from);
+        const senderIsAdmin = metadata.participants.some(p => areJidsSameUser(p.id, senderId) && p.admin);
+
+        if (senderIsAdmin) {
+          // This is a safeguard. An admin should not be in the muted list,
+          // but if they are, we should not delete their messages.
+          // Optionally, we could also remove them from the muted list here.
+          return;
+        }
+
+        // Delete the message from the muted user
+        await sock.sendMessage(from, { delete: msg.key });
+      }
+    } catch (error) {
+      console.error("Error in mute-handler:", error);
+    }
+  }
+};
+
+export default muteHandler;

--- a/plugins/mute.js
+++ b/plugins/mute.js
@@ -1,0 +1,54 @@
+import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+import { getUserFromMessage } from '../lib/utils.js';
+import { areJidsSameUser } from '@whiskeysockets/baileys';
+
+const muteCommand = {
+  name: "mute",
+  category: "grupos",
+  description: "Silencia a un usuario en el grupo, eliminando sus mensajes.",
+  group: true,
+  admin: true,
+
+  async execute({ sock, msg, args }) {
+    const from = msg.key.remoteJid;
+    const userToMute = getUserFromMessage(msg, args);
+
+    if (!userToMute) {
+      return sock.sendMessage(from, { text: "Debes mencionar a un usuario o responder a su mensaje para silenciarlo." }, { quoted: msg });
+    }
+
+    try {
+      const metadata = await sock.groupMetadata(from);
+
+      // Check if the target user is an admin
+      const targetIsAdmin = metadata.participants.some(p => areJidsSameUser(p.id, userToMute) && p.admin);
+      if (targetIsAdmin) {
+        return sock.sendMessage(from, { text: "No se puede silenciar a un administrador del grupo." }, { quoted: msg });
+      }
+
+      const settings = readSettingsDb();
+      if (!settings[from]) {
+        settings[from] = {};
+      }
+      if (!settings[from].mutedUsers) {
+        settings[from].mutedUsers = [];
+      }
+
+      // Check if user is already muted
+      if (settings[from].mutedUsers.includes(userToMute)) {
+        return sock.sendMessage(from, { text: "Este usuario ya está silenciado." }, { quoted: msg });
+      }
+
+      settings[from].mutedUsers.push(userToMute);
+      writeSettingsDb(settings);
+
+      await sock.sendMessage(from, { text: `✅ @${userToMute.split('@')[0]} ha sido silenciado. Sus mensajes serán eliminados.`, mentions: [userToMute] }, { quoted: msg });
+
+    } catch (error) {
+      console.error("Error in mute command:", error);
+      await sock.sendMessage(from, { text: "❌ Ocurrió un error al intentar silenciar al usuario." }, { quoted: msg });
+    }
+  }
+};
+
+export default muteCommand;

--- a/plugins/unmute.js
+++ b/plugins/unmute.js
@@ -1,0 +1,40 @@
+import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+import { getUserFromMessage } from '../lib/utils.js';
+
+const unmuteCommand = {
+  name: "unmute",
+  category: "grupos",
+  description: "Permite que un usuario silenciado vuelva a enviar mensajes.",
+  group: true,
+  admin: true,
+
+  async execute({ sock, msg, args }) {
+    const from = msg.key.remoteJid;
+    const userToUnmute = getUserFromMessage(msg, args);
+
+    if (!userToUnmute) {
+      return sock.sendMessage(from, { text: "Debes mencionar a un usuario o responder a su mensaje para quitarle el silencio." }, { quoted: msg });
+    }
+
+    try {
+      const settings = readSettingsDb();
+      const groupSettings = settings[from];
+
+      if (!groupSettings || !groupSettings.mutedUsers || !groupSettings.mutedUsers.includes(userToUnmute)) {
+        return sock.sendMessage(from, { text: "Este usuario no está silenciado." }, { quoted: msg });
+      }
+
+      // Remove the user from the muted list
+      settings[from].mutedUsers = settings[from].mutedUsers.filter(jid => jid !== userToUnmute);
+      writeSettingsDb(settings);
+
+      await sock.sendMessage(from, { text: `✅ @${userToUnmute.split('@')[0]} ya no está silenciado.`, mentions: [userToUnmute] }, { quoted: msg });
+
+    } catch (error) {
+      console.error("Error in unmute command:", error);
+      await sock.sendMessage(from, { text: "❌ Ocurrió un error al intentar quitar el silencio al usuario." }, { quoted: msg });
+    }
+  }
+};
+
+export default unmuteCommand;


### PR DESCRIPTION
…es, including new features, critical bug fixes, and refactoring based on extensive user feedback.

- **feat(dash):** Adds a new `dash` command for the bot owner. This command displays a dashboard with statistics, including command usage, bot uptime, and system memory. It uses a new internal `formatBytes` utility to ensure reliable output.

- **feat(antilink):** Replaces the basic antilink toggle with a powerful, unified auto-handler and command. The new system supports multiple levels of protection (WhatsApp links vs. all links), ignores admins and links to the current group, and deletes the offending message before kicking the user.

- **feat(mute):** Adds new `mute` and `unmute` commands for group admins. Admins can now mute non-admin users, which will cause the bot to automatically delete any messages they send. An auto-handler (`mute-handler.js`) was created to manage this.

- **fix(admin):** Replaces flawed manual JID normalization with the official `areJidsSameUser` function from the Baileys library. This is the correct and robust method for comparing user JIDs and definitively resolves the bug where the bot failed to recognize admin privileges due to JID variations (e.g., LIDs).

- **refactor(user-extraction):** The user identification logic in the `promote`, `demote`, `kick`, and `mute` commands has been refactored into a reusable `getUserFromMessage` function in `lib/utils.js`, simplifying the commands and reducing code duplication.

- **chore(admin-commands):** The `botAdmin` check has been removed from the `promote`, `demote`, `kick`, and `link` commands. This allows the commands to proceed as long as the user is an admin, without checking the bot's own permissions, per user request.