### PR TITLE
feat(rpg): Overhaul with Durability, Professions, and Crafting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,12 +71,15 @@ export function initializeRpgUser(user) {
   // Initialize durability for existing equipment
   for (const itemType in user.equipment) {
     const item = user.equipment[itemType];
-    if (item && item.durability === undefined) {
-      item.durability = 100;
-      item.maxDurability = 100;
-    }
-     if (item && item.level === undefined) {
-      item.level = 1;
+    // AÑADIDO: Comprobar que el item no sea null antes de modificarlo
+    if (item) {
+      if (item.durability === undefined) {
+        item.durability = 100;
+        item.maxDurability = 100;
+      }
+      if (item.level === undefined) {
+        item.level = 1;
+      }
     }
   }
 }


### PR DESCRIPTION
This major update completely revamps the RPG system, introducing new mechanics, fixing critical bugs, and improving overall stability.

- **Centralized User Initialization:**
  - A new `initializeRpgUser` function in `lib/utils.js` ensures all player profiles are standardized, preventing errors with legacy data by assigning default values for new stats (`hp`, `maxHp`, `durability`, `profession`, etc.).
  - This function is now called at the beginning of all RPG commands (`hunt`, `mine`, `blacksmith`, `inventory`, `profile`, `professions`), guaranteeing data integrity.

- **Consolidated Blacksmith Command:**
  - The old `craft.js` and `smith.js` plugins have been removed.
  - A new, robust `blacksmith.js` command now centralizes all item-related actions: crafting, upgrading (with a failure chance), and repairing.

- **New Gameplay Mechanics:**
  - **Item Durability:** Equipment now has durability that depletes with use in combat (`hunt`). Broken items offer no stats.
  - **Professions:** A new `professions.js` command allows players to choose a class (`Miner` or `Blacksmith`) for specialized in-game bonuses.
  - **Expanded Resources:** New rare materials (`gold`, `mithril`) can be found while mining, required for high-tier equipment.

- **UI and UX Enhancements:**
  - The `inventory` command now displays equipped items with their level and durability.
  - A new `profile` command provides a comprehensive summary of a player's RPG stats.
  - All related commands have been updated to reflect the new mechanics.