### PR TITLE
feat: Add config command to view group settings

### DIFF
--- a/plugins/config.js
+++ b/plugins/config.js
@@ -1,0 +1,41 @@
+import { readSettingsDb } from '../lib/database.js';
+import { areJidsSameUser } from '@whiskeysockets/baileys';
+
+const configCommand = {
+  name: "config",
+  category: "grupos",
+  description: "Muestra la configuración actual del bot para este grupo.",
+  aliases: ["settings", "ajustes"],
+  group: true,
+  admin: true,
+
+  async execute({ sock, msg }) {
+    const from = msg.key.remoteJid;
+    const settings = readSettingsDb();
+    const groupSettings = settings[from] || {};
+
+    // Función para obtener el estado como emoji y texto
+    const getStatus = (value) => {
+      return value ? "✅ Activado" : "❌ Desactivado";
+    };
+
+    const adminModeStatus = getStatus(groupSettings.adminMode);
+    const welcomeStatus = getStatus(groupSettings.welcome);
+    const byeStatus = getStatus(groupSettings.bye);
+    const prefix = groupSettings.prefix ? `\`${groupSettings.prefix}\`` : "No establecido (usa el global)";
+
+    let configMessage = `*⚙️ Configuración del Bot para este Grupo ⚙️*\n\n`;
+    configMessage += `1. *Modo Admin:* ${adminModeStatus}\n`;
+    configMessage += `   - _Si está activado, solo los admins pueden usar el bot._\n\n`;
+    configMessage += `2. *Bienvenidas:* ${welcomeStatus}\n`;
+    configMessage += `   - _Mensaje de bienvenida para nuevos miembros._\n\n`;
+    configMessage += `3. *Despedidas:* ${byeStatus}\n`;
+    configMessage += `   - _Mensaje de despedida cuando alguien se va._\n\n`;
+    configMessage += `4. *Prefijo del Grupo:* ${prefix}\n`;
+    configMessage += `   - _Prefijo personalizado para los comandos en este grupo._\n`;
+
+    await sock.sendMessage(from, { text: configMessage.trim() }, { quoted: msg });
+  }
+};
+
+export default configCommand;


### PR DESCRIPTION
This commit introduces a new command, `config`, designed for group administrators to easily view the current bot settings for their group.

The command (`.config`, aliases: `.settings`, `.ajustes`) displays the status (enabled/disabled) of key features:
- **Admin Mode:** Shows if the bot is restricted to admins only.
- **Welcome Messages:** Shows if welcome messages for new members are active.
- **Bye Messages:** Shows if farewell messages are active.
- **Group Prefix:** Displays the custom prefix for the group, if one is set.

This command requires the user to be a group administrator, providing a secure way to check the bot's configuration without needing to remember which settings have been enabled.