### PR TITLE
feat: Add command to enable/disable RPG system in groups

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -78,6 +78,12 @@ export async function handler(m, isSubBot = false) {
       }
       // --- Fin de la Verificación ---
 
+      // --- Verificación de Modo RPG ---
+      if (isGroup && settings[from]?.rpgEnabled === false && command.category === 'rpg' && !isOwner) {
+        return sock.sendMessage(from, { text: "Los comandos de RPG están desactivados en este grupo." }, { quoted: msg });
+      }
+      // --- Fin de la Verificación ---
+
       // --- Verificaciones de Permisos por Comando ---
       if (command.category === 'propietario' && !isOwner) {
         return sock.sendMessage(from, { text: "Este comando es solo para el propietario del bot." });

--- a/plugins/menu.js
+++ b/plugins/menu.js
@@ -1,5 +1,8 @@
+import { readSettingsDb } from '../lib/database.js';
+
 // 🔱 Mapa de emojis para las categorías temático de Gura
 const categoryEmojis = {
+  'rpg': '⚔️',
   'general': '🔱',
   'descargas': '🌊',
   'diversion': '🐟',
@@ -10,7 +13,8 @@ const categoryEmojis = {
   'informacion': '📚',
   'sub-bots': '🤖',
   'ia': '🧠',
-  'otros': '⚙️'
+  'otros': '⚙️',
+  'rpg': '⚔️'
 };
 
 // 🌊 Estilos de bordes temáticos de Gura
@@ -31,6 +35,12 @@ const menuCommand = {
   async execute({ sock, msg, commands, config }) {
     const categories = {};
     const senderName = msg.pushName || 'Chumbie';
+    const from = msg.key.remoteJid;
+
+    // --- Verificación de RPG activado ---
+    const settings = readSettingsDb();
+    const groupSettings = settings[from] || {};
+    const isRpgDisabled = from.endsWith('@g.us') && groupSettings.rpgEnabled === false;
 
     // 🔀 Elegir un estilo aleatorio
     const border = borders[Math.floor(Math.random() * borders.length)];
@@ -38,6 +48,10 @@ const menuCommand = {
     // Agrupar comandos por categoría
     commands.forEach(command => {
       if (!command.category || command.name === 'test') return;
+
+      // Ocultar la categoría RPG si está desactivada en el grupo
+      if (isRpgDisabled && command.category === 'rpg') return;
+
       const category = command.category.toLowerCase();
       if (!categories[category]) categories[category] = [];
       categories[category].push(command);
@@ -54,7 +68,7 @@ const menuCommand = {
     menuText += `${border.bot}\n\n`;
 
     for (const category of sortedCategories) {
-      const emoji = categoryEmojis[category] || '🔱';
+      const emoji = categoryEmojis[category] || '⚙️';
       menuText += `${border.top} ${emoji} *${category.toUpperCase()}* 』\n`;
 
       const commandList = categories[category]

--- a/plugins/rpg.js
+++ b/plugins/rpg.js
@@ -1,0 +1,36 @@
+import { readSettingsDb, writeSettingsDb } from '../lib/database.js';
+
+const rpgToggleCommand = {
+  name: "rpg",
+  category: "grupos",
+  description: "Activa o desactiva todos los comandos de RPG en este grupo.",
+  aliases: ["rpgmode"],
+  group: true,
+  admin: true,
+
+  async execute({ sock, msg, args }) {
+    const from = msg.key.remoteJid;
+    const option = args[0]?.toLowerCase();
+
+    if (option !== 'on' && option !== 'off') {
+      return sock.sendMessage(from, { text: "Por favor, especifica una opción: `on` o `off`.\n\nEjemplo: `.rpg on`" }, { quoted: msg });
+    }
+
+    const settings = readSettingsDb();
+    if (!settings[from]) {
+      settings[from] = {};
+    }
+
+    const isEnabling = option === 'on';
+    settings[from].rpgEnabled = isEnabling;
+    writeSettingsDb(settings);
+
+    const message = isEnabling
+      ? "✅ El sistema de RPG ha sido **activado** en este grupo."
+      : "❌ El sistema de RPG ha sido **desactivado** en este grupo. Los comandos no funcionarán ni aparecerán en el menú.";
+
+    await sock.sendMessage(from, { text: message }, { quoted: msg });
+  }
+};
+
+export default rpgToggleCommand;


### PR DESCRIPTION
This commit introduces a new feature that allows group administrators to enable or disable the entire RPG system within their group.

- **New `rpg` command:**
  - A new command `.rpg on|off` has been created for group admins.
  - This command saves the group's preference to the `groupSettings.json` database.

- **Handler Logic Update:**
  - The main message handler (`handler.js`) has been updated to check the `rpgEnabled` status for each group.
  - If RPG is disabled, any command with the category 'rpg' will be blocked, and a message will be sent to the user. The bot owner is exempt from this restriction.

- **Dynamic Menu:**
  - The `menu.js` command has been modified to dynamically hide the entire 'RPG' category and its commands if the system is disabled in the group where the menu is requested.

This provides greater control for group admins over the bot's functionality.