### PR TITLE
feat: Add owner-only cmd command for shell execution

### DIFF
--- a/plugins/cmd.js
+++ b/plugins/cmd.js
@@ -1,0 +1,48 @@
+import { exec } from 'child_process';
+import util from 'util';
+
+const execPromise = util.promisify(exec);
+
+const cmdCommand = {
+  name: "cmd",
+  category: "propietario",
+  description: "Ejecuta un comando en la terminal del servidor.",
+  aliases: ["$"],
+  owner: true, // Doble seguridad, aunque la categoría ya lo restringe.
+
+  async execute({ sock, msg, text }) {
+    if (!text) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona un comando para ejecutar." }, { quoted: msg });
+    }
+
+    await sock.sendMessage(msg.key.remoteJid, { react: { text: "⚙️", key: msg.key } });
+
+    try {
+      const { stdout, stderr } = await execPromise(text);
+      let output = "";
+
+      if (stdout) {
+        output += `*Salida (stdout):*\n\`\`\`${stdout.trim()}\`\`\`\n\n`;
+      }
+      if (stderr) {
+        output += `*Errores (stderr):*\n\`\`\`${stderr.trim()}\`\`\`\n\n`;
+      }
+
+      if (output.trim() === "") {
+        output = "✅ Comando ejecutado sin salida.";
+      }
+
+      await sock.sendMessage(msg.key.remoteJid, { text: output.trim() }, { quoted: msg });
+      await sock.sendMessage(msg.key.remoteJid, { react: { text: "✅", key: msg.key } });
+
+    } catch (error) {
+      console.error("Error en el comando 'cmd':", error);
+      await sock.sendMessage(msg.key.remoteJid, { react: { text: "❌", key: msg.key } });
+
+      const errorMessage = `*Error de Ejecución:*\n\`\`\`${error.message}\`\`\``;
+      await sock.sendMessage(msg.key.remoteJid, { text: errorMessage }, { quoted: msg });
+    }
+  }
+};
+
+export default cmdCommand;


### PR DESCRIPTION
This commit introduces a new command, `cmd` (aliased as `$`), which is restricted to the bot owner. This command allows the owner to execute shell commands directly on the server where the bot is running and receive the output back in the chat.

- **Functionality:**
  - The command takes a string as input and executes it in the system's shell using Node.js's `child_process.exec`.
  - It captures and returns both standard output (`stdout`) and standard error (`stderr`), providing comprehensive feedback for any command.
  - If a command executes successfully but produces no output, a confirmation message is sent.
  - Any execution errors are caught and sent back to the owner for debugging.

- **Security:**
  - The command is placed in the 'propietario' category and includes an explicit `owner: true` flag, ensuring it can only be used by the numbers listed in `config.js`.

This serves as a powerful tool for live debugging, server management, and testing from within WhatsApp.