### PR TITLE
fix: Update dependencies and repair sticker command

### DIFF
--- a/plugins/sticker.js
+++ b/plugins/sticker.js
@@ -1,5 +1,6 @@
 import { downloadContentFromMessage } from '@whiskeysockets/baileys';
-import { Sticker, StickerTypes } from 'wa-sticker-formatter';
+import StickerFormatter from 'wa-sticker-formatter';
+const { Sticker, StickerTypes } = StickerFormatter;
 import axios from 'axios';
 
 // Función para validar si un texto es una URL de imagen/video válida


### PR DESCRIPTION
This commit resolves a critical issue that occurred after updating all project dependencies to their latest versions. The update fixed several security vulnerabilities but introduced a breaking change in the `wa-sticker-formatter` library, which caused the `sticker` command to fail.

- **Dependency Update:**
  - All dependencies in `package.json` have been updated to their latest stable versions.
  - Security vulnerabilities reported by `npm audit` have been addressed.

- **Sticker Command Fix:**
  - The import statement in `plugins/sticker.js` has been corrected to align with the new module format of `wa-sticker-formatter`.
  - The command now correctly imports the `Sticker` and `StickerTypes` classes, resolving the `SyntaxError: Named export not found` and making the command fully functional again.