### PR TITLE
fix(docs): Update example message in setwelcome command

### DIFF
--- a/plugins/setwelcome.js
+++ b/plugins/setwelcome.js
@@ -44,7 +44,7 @@ const setWelcomeCommand = {
     }
 
     if (!welcomeText) {
-        return sock.sendMessage(from, { text: "Por favor, proporciona un mensaje de bienvenida. Ejemplo: `setwelcome ¡Bienvenido @user al grupo!`" }, { quoted: msg });
+        return sock.sendMessage(from, { text: "Por favor, proporciona un mensaje de bienvenida. Revisa el comando `menu` para ver todas las variables disponibles.\n\n*Ejemplo:*\n`.setwelcome ¡Hola @user! Bienvenido a @subject. Somos @count miembros.`" }, { quoted: msg });
     }
 
     settings[from].welcome = true;


### PR DESCRIPTION
This commit fixes an oversight where the example usage message within the `setwelcome` command was not updated to reflect the new dynamic variables.

Previously, if a user ran the command without providing a message, the example shown was outdated (`.setwelcome ¡Bienvenido @user al grupo!`).

The example message has now been updated to showcase the new variables (e.g., `@subject`, `@count`), providing a clearer and more helpful guide to administrators directly within the command's response.