### PR TITLE
feat(rpg): Implement advanced gacha system (Phases 1 & 2)

### DIFF
--- a/plugins/accepttrade.js
+++ b/plugins/accepttrade.js
@@ -1,0 +1,98 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import { initializeRpgUser } from '../lib/utils.js';
+import fs from 'fs';
+
+const TRADES_FILE_PATH = './database/gacha_trades.json';
+
+const readTradesDb = () => {
+    try {
+        if (!fs.existsSync(TRADES_FILE_PATH)) return [];
+        const data = fs.readFileSync(TRADES_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        return [];
+    }
+};
+
+const writeTradesDb = (data) => {
+    fs.writeFileSync(TRADES_FILE_PATH, JSON.stringify(data, null, 2));
+};
+
+const acceptTradeCommand = {
+  name: "accepttrade",
+  category: "rpg",
+  description: "Acepta una propuesta de intercambio de waifus. Uso: .accepttrade <ID_del_trade>",
+  aliases: ["aceptarintercambio"],
+  group: true,
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+    const tradeId = args[0];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado en el RPG." }, { quoted: msg });
+    }
+    initializeRpgUser(user);
+
+    if (!tradeId) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona el ID del intercambio que quieres aceptar." }, { quoted: msg });
+    }
+
+    const trades = readTradesDb();
+    const tradeIndex = trades.findIndex(t => t.id === tradeId);
+
+    if (tradeIndex === -1) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No se encontró ninguna propuesta de intercambio con ese ID." }, { quoted: msg });
+    }
+
+    const trade = trades[tradeIndex];
+
+    if (trade.to !== senderId) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No puedes aceptar un intercambio que no es para ti." }, { quoted: msg });
+    }
+
+    const tradeExpiryMs = 5 * 60 * 1000; // 5 minutos
+    if (Date.now() - trade.createdAt > tradeExpiryMs) {
+      trades.splice(tradeIndex, 1);
+      writeTradesDb(trades);
+      return sock.sendMessage(msg.key.remoteJid, { text: "Esta propuesta de intercambio ya ha expirado." }, { quoted: msg });
+    }
+
+    const fromUser = usersDb[trade.from];
+    const toUser = usersDb[trade.to];
+    initializeRpgUser(fromUser);
+    initializeRpgUser(toUser);
+
+    const fromWaifuIndex = fromUser.harem.findIndex(w => w.id === trade.fromWaifu.id);
+    const toWaifuIndex = toUser.harem.findIndex(w => w.id === trade.toWaifu.id);
+
+    if (fromWaifuIndex === -1 || toWaifuIndex === -1) {
+      trades.splice(tradeIndex, 1);
+      writeTradesDb(trades);
+      return sock.sendMessage(msg.key.remoteJid, { text: "El intercambio no se puede completar porque uno de los jugadores ya no posee la waifu ofrecida." }, { quoted: msg });
+    }
+
+    // Realizar el intercambio
+    const [fromWaifu] = fromUser.harem.splice(fromWaifuIndex, 1);
+    const [toWaifu] = toUser.harem.splice(toWaifuIndex, 1);
+
+    fromUser.harem.push(toWaifu);
+    toUser.harem.push(fromWaifu);
+
+    // Eliminar la propuesta de la base de datos
+    trades.splice(tradeIndex, 1);
+
+    writeUsersDb(usersDb);
+    writeTradesDb(trades);
+
+    const successMessage = `*🔄 ¡Intercambio Completado! 🔄*\n\n` +
+                           `@${fromUser.id.split('@')[0]} ha recibido a *${toWaifu.name}*.\n` +
+                           `@${toUser.id.split('@')[0]} ha recibido a *${fromWaifu.name}*.`;
+
+    await sock.sendMessage(msg.key.remoteJid, { text: successMessage, mentions: [trade.from, trade.to] });
+  }
+};
+
+export default acceptTradeCommand;

--- a/plugins/buywaifu.js
+++ b/plugins/buywaifu.js
@@ -1,0 +1,90 @@
+import { readUsersDb, writeUsersDb, readSettingsDb } from '../lib/database.js';
+import { initializeRpgUser } from '../lib/utils.js';
+import fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+
+const SHOP_FILE_PATH = './database/gacha_shop.json';
+
+// --- Helper Functions ---
+const getCharacters = () => {
+  try {
+    const data = fs.readFileSync('./lib/characters.json', 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.error("Error al leer lib/characters.json:", error);
+    return [];
+  }
+};
+
+const readShopDb = () => {
+    try {
+        if (!fs.existsSync(SHOP_FILE_PATH)) return {};
+        const data = fs.readFileSync(SHOP_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        return {};
+    }
+};
+
+const buyWaifuCommand = {
+  name: "buywaifu",
+  category: "rpg",
+  description: "Compra una waifu de la tienda. Uso: .buywaifu <nombre>",
+  aliases: ["comprarwaifu"],
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+    const characterNameToBuy = args.join(" ").toLowerCase();
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado. Usa el comando `reg` para registrarte." }, { quoted: msg });
+    }
+
+    initializeRpgUser(user);
+
+    if (!characterNameToBuy) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, especifica el nombre de la waifu que quieres comprar de la `.waifushop`." }, { quoted: msg });
+    }
+
+    const shop = readShopDb();
+    const itemInShop = shop.stock?.find(item => item.name.toLowerCase() === characterNameToBuy);
+
+    if (!itemInShop) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `"${args.join(" ")}" no está a la venta en la tienda de hoy.` }, { quoted: msg });
+    }
+
+    if ((user.coins || 0) < itemInShop.value) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `No tienes suficientes WFCoins. Necesitas ${itemInShop.value} para comprar a ${itemInShop.name}.` }, { quoted: msg });
+    }
+
+    const alreadyOwned = user.harem.some(w => w.name.toLowerCase() === characterNameToBuy);
+    if (alreadyOwned) {
+        return sock.sendMessage(msg.key.remoteJid, { text: `Ya tienes a ${itemInShop.name} en tu harén.` }, { quoted: msg });
+    }
+
+    const allCharacters = getCharacters();
+    const characterData = allCharacters.find(c => c.name.toLowerCase() === characterNameToBuy);
+
+    if (!characterData) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "Ocurrió un error al obtener los datos de la waifu. Inténtalo de nuevo." }, { quoted: msg });
+    }
+
+    // Proceder con la compra
+    user.coins -= itemInShop.value;
+
+    const newWaifu = {
+        ...characterData,
+        id: uuidv4()
+    };
+    user.harem.push(newWaifu);
+
+    writeUsersDb(usersDb);
+
+    const successMessage = `*🛍️ ¡Compra Exitosa! 🛍️*\n\nHas comprado a *${itemInShop.name}* por ${itemInShop.value} WFCoins. ¡Se ha unido a tu harén!`;
+    await sock.sendMessage(msg.key.remoteJid, { text: successMessage }, { quoted: msg });
+  }
+};
+
+export default buyWaifuCommand;

--- a/plugins/rejecttrade.js
+++ b/plugins/rejecttrade.js
@@ -1,0 +1,59 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import fs from 'fs';
+
+const TRADES_FILE_PATH = './database/gacha_trades.json';
+
+const readTradesDb = () => {
+    try {
+        if (!fs.existsSync(TRADES_FILE_PATH)) return [];
+        const data = fs.readFileSync(TRADES_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        return [];
+    }
+};
+
+const writeTradesDb = (data) => {
+    fs.writeFileSync(TRADES_FILE_PATH, JSON.stringify(data, null, 2));
+};
+
+const rejectTradeCommand = {
+  name: "rejecttrade",
+  category: "rpg",
+  description: "Rechaza una propuesta de intercambio de waifus. Uso: .rejecttrade <ID_del_trade>",
+  aliases: ["rechazarintercambio"],
+  group: true,
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const tradeId = args[0];
+
+    if (!tradeId) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Por favor, proporciona el ID del intercambio que quieres rechazar." }, { quoted: msg });
+    }
+
+    const trades = readTradesDb();
+    const tradeIndex = trades.findIndex(t => t.id === tradeId);
+
+    if (tradeIndex === -1) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No se encontró ninguna propuesta de intercambio con ese ID." }, { quoted: msg });
+    }
+
+    const trade = trades[tradeIndex];
+
+    // Solo el destinatario o el que envió la propuesta pueden rechazarla
+    if (trade.to !== senderId && trade.from !== senderId) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No puedes rechazar un intercambio que no te concierne." }, { quoted: msg });
+    }
+
+    trades.splice(tradeIndex, 1);
+    writeTradesDb(trades);
+
+    const rejectionMessage = `*❌ Intercambio Rechazado ❌*\n\n` +
+                             `La propuesta de intercambio (ID: \`${trade.id}\`) entre @${trade.from.split('@')[0]} y @${trade.to.split('@')[0]} ha sido cancelada.`;
+
+    await sock.sendMessage(msg.key.remoteJid, { text: rejectionMessage, mentions: [trade.from, trade.to] });
+  }
+};
+
+export default rejectTradeCommand;

--- a/plugins/trades.js
+++ b/plugins/trades.js
@@ -1,0 +1,66 @@
+import fs from 'fs';
+import { initializeRpgUser } from '../lib/utils.js';
+
+const TRADES_FILE_PATH = './database/gacha_trades.json';
+
+const readTradesDb = () => {
+    try {
+        if (!fs.existsSync(TRADES_FILE_PATH)) return [];
+        const data = fs.readFileSync(TRADES_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        return [];
+    }
+};
+
+const tradesCommand = {
+  name: "trades",
+  category: "rpg",
+  description: "Muestra tus propuestas de intercambio pendientes (enviadas y recibidas).",
+  aliases: ["intercambios"],
+  group: true,
+
+  async execute({ sock, msg }) {
+    const senderId = msg.sender;
+    let trades = readTradesDb();
+
+    // Eliminar propuestas expiradas (más de 5 minutos)
+    const now = Date.now();
+    const tradeExpiryMs = 5 * 60 * 1000;
+    trades = trades.filter(t => (now - t.createdAt) < tradeExpiryMs);
+
+    const myTrades = trades.filter(t => t.from === senderId || t.to === senderId);
+
+    if (myTrades.length === 0) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No tienes ninguna propuesta de intercambio activa en este momento." }, { quoted: msg });
+    }
+
+    let tradesMessage = `*📬 Tus Intercambios Pendientes 📬*\n\n`;
+
+    const sentTrades = myTrades.filter(t => t.from === senderId);
+    const receivedTrades = myTrades.filter(t => t.to === senderId);
+
+    if (sentTrades.length > 0) {
+        tradesMessage += "*Enviados por ti:*\n";
+        sentTrades.forEach(trade => {
+            tradesMessage += `> ↔️ ID: \`${trade.id}\`\n` +
+                             `  - Ofreces: *${trade.fromWaifu.name}*\n` +
+                             `  - Pides a @${trade.to.split('@')[0]}: *${trade.toWaifu.name}*\n\n`;
+        });
+    }
+
+    if (receivedTrades.length > 0) {
+        tradesMessage += "*Recibidos de otros:*\n";
+        receivedTrades.forEach(trade => {
+            tradesMessage += `> ↔️ ID: \`${trade.id}\`\n` +
+                             `  - @${trade.from.split('@')[0]} te ofrece: *${trade.fromWaifu.name}*\n` +
+                             `  - A cambio de tu: *${trade.toWaifu.name}*\n` +
+                             `  - Para aceptar: \`.accepttrade ${trade.id}\`\n\n`;
+        });
+    }
+
+    await sock.sendMessage(msg.key.remoteJid, { text: tradesMessage.trim() }, { quoted: msg });
+  }
+};
+
+export default tradesCommand;

--- a/plugins/tradewaifu.js
+++ b/plugins/tradewaifu.js
@@ -1,0 +1,98 @@
+import { readUsersDb, writeUsersDb } from '../lib/database.js';
+import { initializeRpgUser, getUserFromMessage } from '../lib/utils.js';
+import fs from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+
+const TRADES_FILE_PATH = './database/gacha_trades.json';
+
+const readTradesDb = () => {
+    try {
+        if (!fs.existsSync(TRADES_FILE_PATH)) return [];
+        const data = fs.readFileSync(TRADES_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        return [];
+    }
+};
+
+const writeTradesDb = (data) => {
+    fs.writeFileSync(TRADES_FILE_PATH, JSON.stringify(data, null, 2));
+};
+
+const tradeWaifuCommand = {
+  name: "tradewaifu",
+  category: "rpg",
+  description: "Propón un intercambio de waifus a otro usuario.\nUso: .tradewaifu <ID de tu waifu> @usuario <ID de su waifu>",
+  aliases: ["intercambiarwaifu"],
+  group: true,
+
+  async execute({ sock, msg, args }) {
+    const senderId = msg.sender;
+    const usersDb = readUsersDb();
+    const user = usersDb[senderId];
+
+    if (!user) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "No estás registrado en el RPG." }, { quoted: msg });
+    }
+    initializeRpgUser(user);
+
+    if (args.length < 3) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Formato incorrecto. Uso: `.tradewaifu <ID_tuya> @usuario <ID_suya>`" }, { quoted: msg });
+    }
+
+    const myWaifuId = args[0];
+    const targetId = getUserFromMessage(msg, args.slice(1));
+    const targetWaifuId = args.slice(-1)[0];
+
+    if (!targetId || !usersDb[targetId]) {
+      return sock.sendMessage(msg.key.remoteJid, { text: "Debes mencionar a un usuario válido para el intercambio." }, { quoted: msg });
+    }
+    if (targetId === senderId) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "No puedes intercambiar contigo mismo." }, { quoted: msg });
+    }
+
+    const myWaifu = user.harem.find(w => w.id === myWaifuId);
+    if (!myWaifu) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `No tienes ninguna waifu con el ID \`${myWaifuId}\`.` }, { quoted: msg });
+    }
+
+    const targetUser = usersDb[targetId];
+    initializeRpgUser(targetUser);
+    const targetWaifu = targetUser.harem.find(w => w.id === targetWaifuId);
+    if (!targetWaifu) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `El otro jugador no tiene una waifu con el ID \`${targetWaifuId}\`.` }, { quoted: msg });
+    }
+
+    const tradeId = uuidv4().slice(0, 6);
+    const trades = readTradesDb();
+
+    const newTrade = {
+        id: tradeId,
+        from: senderId,
+        to: targetId,
+        fromWaifu: myWaifu,
+        toWaifu: targetWaifu,
+        createdAt: Date.now()
+    };
+    trades.push(newTrade);
+    writeTradesDb(trades);
+
+    const proposalMessage = `*📬 Nueva Propuesta de Intercambio 📬*\n\n` +
+                            `@${senderId.split('@')[0]} quiere intercambiar su waifu:\n` +
+                            `> *${myWaifu.name}* (ID: \`${myWaifu.id}\`)\n\n` +
+                            `Por tu waifu:\n` +
+                            `> *${targetWaifu.name}* (ID: \`${targetWaifu.id}\`)\n\n` +
+                            `Para aceptar, usa el comando:\n` +
+                            `\`.accepttrade ${tradeId}\`\n\n` +
+                            `Para rechazar:\n` +
+                            `\`.rejecttrade ${tradeId}\`\n\n` +
+                            `_Esta propuesta expira en 5 minutos._`;
+
+    await sock.sendMessage(msg.key.remoteJid, {
+        text: proposalMessage,
+        mentions: [senderId, targetId]
+    });
+  }
+};
+
+export default tradeWaifuCommand;

--- a/plugins/waifushop.js
+++ b/plugins/waifushop.js
@@ -1,0 +1,91 @@
+import { readUsersDb, writeUsersDb, readSettingsDb } from '../lib/database.js';
+import { initializeRpgUser } from '../lib/utils.js';
+import fs from 'fs';
+
+const SHOP_FILE_PATH = './database/gacha_shop.json';
+
+// --- Helper Functions ---
+const getCharacters = () => {
+  try {
+    const data = fs.readFileSync('./lib/characters.json', 'utf8');
+    return JSON.parse(data);
+  } catch (error) {
+    console.error("Error al leer lib/characters.json:", error);
+    return [];
+  }
+};
+
+const readShopDb = () => {
+    try {
+        if (!fs.existsSync(SHOP_FILE_PATH)) return {};
+        const data = fs.readFileSync(SHOP_FILE_PATH, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        console.error("Error al leer la base de datos de la tienda:", error);
+        return {};
+    }
+};
+
+const writeShopDb = (data) => {
+    try {
+        fs.writeFileSync(SHOP_FILE_PATH, JSON.stringify(data, null, 2));
+    } catch (error) {
+        console.error("Error al escribir en la base de datos de la tienda:", error);
+    }
+};
+
+const refreshShopIfNeeded = () => {
+    const shop = readShopDb();
+    const now = new Date();
+    const today = now.toISOString().split('T')[0]; // YYYY-MM-DD
+
+    if (shop.lastUpdated !== today) {
+        const allCharacters = getCharacters();
+        const stock = [];
+        const numItemsInShop = 5;
+
+        // Seleccionar 5 personajes aleatorios para la tienda
+        for (let i = 0; i < numItemsInShop; i++) {
+            const randomIndex = Math.floor(Math.random() * allCharacters.length);
+            const character = allCharacters[randomIndex];
+            if (!stock.some(s => s.name === character.name)) {
+                stock.push({
+                    name: character.name,
+                    value: Math.floor(character.value * 1.5) // Precio de tienda un 50% más caro
+                });
+            }
+        }
+
+        shop.stock = stock;
+        shop.lastUpdated = today;
+        writeShopDb(shop);
+    }
+    return shop;
+};
+
+
+const waifuShopCommand = {
+  name: "waifushop",
+  category: "rpg",
+  description: "Muestra las waifus disponibles en la tienda de hoy.",
+  aliases: ["tienda", "shop"],
+
+  async execute({ sock, msg }) {
+    const shop = refreshShopIfNeeded();
+
+    if (!shop.stock || shop.stock.length === 0) {
+        return sock.sendMessage(msg.key.remoteJid, { text: "La tienda está vacía en este momento. ¡Vuelve más tarde!" }, { quoted: msg });
+    }
+
+    let shopMessage = `*🏪 Tienda de Waifus 🏪*\n\n¡Estos son los personajes disponibles hoy! Usa \`.buywaifu <nombre>\` para comprar.\n\n`;
+
+    shop.stock.forEach((item, index) => {
+        shopMessage += `${index + 1}. *${item.name}*\n` +
+                       `   - Precio: ${item.value} WFCoins\n\n`;
+    });
+
+    await sock.sendMessage(msg.key.remoteJid, { text: shopMessage.trim() }, { quoted: msg });
+  }
+};
+
+export default waifuShopCommand;


### PR DESCRIPTION
This commit introduces a comprehensive gacha system for collecting, trading, and managing 'waifus'. This feature is divided into two main parts: the core collection system and the economy/interaction system.

**Phase 1: Core Gacha System**
- **`lib/characters.json`**: A new database file containing a large list of characters with names, image URLs, and values.
- **`gacha` command**: Allows users to roll for a random character. Each obtained character is assigned a unique ID (UUID) for management.
- **`harem` command**: Lets users view their personal collection of characters, including their unique IDs.
- **`waifuinfo` command**: Provides detailed information about a specific character by name.

**Phase 2: Economy & Interaction**
- **Daily Shop:**
  - **`waifushop`**: Displays a rotating selection of 5 random characters available for purchase each day.
  - **`buywaifu`**: Allows users to purchase a character from the daily shop using their in-game currency.
- **Secure Trading System:**
  - **`tradewaifu`**: Enables a user to propose a trade with another user, specifying the two characters to be exchanged by their unique IDs.
  - **`accepttrade`**: Allows the recipient of a trade offer to accept it, which then executes the swap of characters between the two users.
  - **`rejecttrade`**: Allows either party to cancel a pending trade proposal.
  - **`trades`**: Lets users view their pending incoming and outgoing trade offers.
- **Economy Integration:**
  - **`sellwaifu`**: Allows players to sell a character from their collection for its value in coins.

All new commands are integrated with the existing RPG system and use the `initializeRpgUser` utility to ensure data consistency.