### PR TITLE
feat: Add qc command, update warn, and refactor pinterest

### DIFF
--- a/plugins/pinterest.js
+++ b/plugins/pinterest.js
@@ -1,105 +1,69 @@
 import axios from 'axios';
-import baileys from '@whiskeysockets/baileys';
+import https from 'https';
 
-// --- Helper para enviar álbumes ---
-async function sendAlbum(sock, jid, medias, options = {}) {
-  if (!medias || medias.length < 2) {
-    throw new Error("Se necesitan al menos 2 imágenes para un álbum.");
-  }
+// Agente para ignorar la validación del certificado SSL, haciendo la conexión más robusta.
+const httpsAgent = new https.Agent({
+  rejectUnauthorized: false,
+});
 
-  const caption = options.caption || "";
-  const delay = options.delay || 500;
-
-  // Generar el mensaje contenedor del álbum
-  const albumMessage = await baileys.generateWAMessageFromContent(
-    jid,
-    { albumMessage: { expectedImageCount: medias.length } },
-    { userJid: sock.user.id }
-  );
-
-  // Enviar el contenedor
-  await sock.relayMessage(albumMessage.key.remoteJid, albumMessage.message, { messageId: albumMessage.key.id });
-
-  // Enviar cada imagen asociada al álbum
-  for (let i = 0; i < medias.length; i++) {
-    const mediaUrl = medias[i];
-    const messageContent = {
-      image: { url: mediaUrl },
-      ...(i === 0 && caption ? { caption } : {}) // Añadir caption solo a la primera
-    };
-
-    const waMessage = await baileys.generateWAMessage(
-      jid,
-      messageContent,
-      {
-        upload: sock.waUploadToServer,
-        quoted: options.quoted
-      }
-    );
-
-    waMessage.message.messageContextInfo = {
-      messageAssociation: {
-        associationType: 1,
-        parentMessageKey: albumMessage.key
-      },
-    };
-
-    await sock.relayMessage(jid, waMessage.message, { messageId: waMessage.key.id });
-    await baileys.delay(delay);
-  }
-
-  return albumMessage;
-}
-
-// --- Comando Principal ---
 const pinterestCommand = {
   name: "pinterest",
   category: "descargas",
-  description: "Busca imágenes en Pinterest y las envía como un álbum.",
+  description: "Busca imágenes en Pinterest. Puedes especificar la cantidad.",
   aliases: ["pin"],
 
-  async execute({ sock, msg, args }) {
-    const query = args.join(' ');
-    if (!query) {
-      return sock.sendMessage(msg.key.remoteJid, { text: `*📌 Uso Correcto:*\n.pin <texto_a_buscar>` }, { quoted: msg });
+  async execute({ sock, msg, text, usedPrefix, command }) {
+    if (!text) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `✧ Por favor, proporciona un término de búsqueda.\n\n*Ejemplo:*\n*${usedPrefix + command} Gura 5*` }, { quoted: msg });
     }
 
-    await sock.sendMessage(msg.key.remoteJid, { react: { text: '⏳', key: msg.key } });
+    const args = text.split(' ');
+    let query = '';
+    let count = 1; // Número de imágenes por defecto
+
+    // Comprobar si el último argumento es un número para la cantidad
+    const lastArg = parseInt(args[args.length - 1], 10);
+    if (!isNaN(lastArg)) {
+      count = Math.min(lastArg, 15); // Limitar a un máximo de 15 para no saturar
+      query = args.slice(0, -1).join(' ');
+    } else {
+      query = text;
+    }
+
+    if (!query) {
+      return sock.sendMessage(msg.key.remoteJid, { text: `✧ Debes proporcionar un término de búsqueda.\n\n*Ejemplo:*\n*${usedPrefix + command} Gura 5*` }, { quoted: msg });
+    }
+
+    await sock.sendMessage(msg.key.remoteJid, { text: `Buscando ${count} imagen(es) de "${query}" en Pinterest...` }, { quoted: m });
+    await sock.sendMessage(msg.key.remoteJid, { react: { text: '🕒', key: msg.key } });
 
     try {
-      const apiUrl = `https://api.dorratz.com/v2/pinterest?q=${encodeURIComponent(query)}`;
-      const { data } = await axios.get(apiUrl);
+      const apiUrl = `https://api.platform.web.id/pinterest?q=${encodeURIComponent(query)}`;
+      const { data } = await axios.get(apiUrl, { httpsAgent });
 
-      if (!Array.isArray(data) || data.length === 0) {
-        await sock.sendMessage(msg.key.remoteJid, { react: { text: '❌', key: msg.key } });
-        return sock.sendMessage(msg.key.remoteJid, { text: `No se encontraron resultados para "${query}".` }, { quoted: msg });
+      if (data.status !== true || !data.results || data.results.length === 0) {
+        throw new Error('No se encontraron imágenes para esa búsqueda.');
       }
 
-      const imageUrls = data.map(item => item.image_large_url).filter(Boolean); // Filtrar por si alguna URL es null
+      const results = data.results;
 
-      if (imageUrls.length === 0) {
-        await sock.sendMessage(msg.key.remoteJid, { react: { text: '❌', key: msg.key } });
-        return sock.sendMessage(msg.key.remoteJid, { text: `No se encontraron imágenes válidas para "${query}".` }, { quoted: msg });
-      }
+      // Barajar el array de resultados para obtener variedad
+      results.sort(() => 0.5 - Math.random());
 
-      const maxImages = Math.min(imageUrls.length, 10);
-      const medias = imageUrls.slice(0, maxImages);
-
-      if (medias.length < 2) {
-        await sock.sendMessage(msg.key.remoteJid, { image: { url: medias[0] }, caption: `*📌 Resultado para:* ${query}` }, { quoted: msg });
-      } else {
-        await sendAlbum(sock, msg.key.remoteJid, medias, {
-          caption: `*📌 Resultados de:* ${query}\n*Imágenes:* ${maxImages}`,
-          quoted: msg
-        });
+      // Enviar el número de imágenes solicitado
+      for (let i = 0; i < Math.min(count, results.length); i++) {
+        await sock.sendMessage(msg.key.remoteJid, {
+            image: { url: results[i] },
+            caption: `Imagen ${i + 1}/${count} de "${query}"`
+        }, { quoted: msg });
       }
 
       await sock.sendMessage(msg.key.remoteJid, { react: { text: '✅', key: msg.key } });
 
     } catch (error) {
-      console.error("Error en el comando pinterest:", error);
+      console.error("Error en el comando Pinterest:", error);
       await sock.sendMessage(msg.key.remoteJid, { react: { text: '❌', key: msg.key } });
-      await sock.sendMessage(msg.key.remoteJid, { text: 'Ocurrió un error al buscar las imágenes en Pinterest.' }, { quoted: msg });
+      await sock.sendMessage(msg.key.remoteJid, { text: `Ocurrió un error al buscar en Pinterest.\n\n*Error:* ${error.message}` }, { quoted: msg });
     }
   }
 };

--- a/plugins/qc.js
+++ b/plugins/qc.js
@@ -1,0 +1,111 @@
+import axios from 'axios';
+import StickerFormatter from 'wa-sticker-formatter';
+const { Sticker, StickerTypes } = StickerFormatter;
+
+const qcCommand = {
+  name: "qc",
+  category: "sticker",
+  description: "Crea un sticker de cita a partir de un texto.",
+  aliases: [],
+
+  async execute({ sock, msg, args, config }) {
+    const from = msg.key.remoteJid;
+    let who = m.quoted ? m.quoted.sender : m.mentionedJid && m.mentionedJid[0] ? m.mentionedJid[0] : m.fromMe ? conn.user.jid : m.sender;
+    let text;
+
+    // Determinar el texto a usar
+    if (m.quoted?.text) {
+        text = m.quoted.text;
+    } else {
+        // Asumimos que el color puede ser el primer argumento
+        text = args.slice(1).join(' ');
+    }
+
+    // Obtener la foto de perfil
+    let ppUrl;
+    try {
+        ppUrl = await sock.profilePictureUrl(who, 'image');
+    } catch {
+        ppUrl = 'https://telegra.ph/file/320b066dc81928b782c7b.png'; // URL por defecto
+    }
+
+    // Limpiar la mención del texto si existe
+    const mentionRegex = new RegExp(`@${who.split('@')[0].replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*`, 'g');
+    const cleanText = text.replace(mentionRegex, '');
+
+    // Obtener el nombre del usuario
+    const userInfo = global.db.data.users[who];
+    const name = userInfo?.name || who.split('@')[0];
+
+    const validColors = {
+        pink: '#FFC0CB', red: '#FF0000', blue: '#0000FF', green: '#008000', yellow: '#FFFF00',
+        black: '#000000', white: '#FFFFFF', orange: '#FFA500', purple: '#800080', brown: '#A52A2A'
+        // Se pueden añadir más colores aquí
+    };
+
+    let color = 'black';
+    if (args.length > 0 && validColors[args[0].toLowerCase()]) {
+        color = args[0].toLowerCase();
+        // Si el texto no fue tomado de un mensaje citado, lo reajustamos para quitar el color
+        if (!m.quoted?.text) {
+            text = args.slice(1).join(' ');
+        }
+    }
+
+    if (!text) {
+        return sock.sendMessage(from, { text: `📌 *Ejemplo de uso:*\n.qc [color] <texto>\n\nO responde a un mensaje con .qc [color]\n\n*Colores disponibles:*\n${Object.keys(validColors).join(', ')}` }, { quoted: msg });
+    }
+
+    const payload = {
+        type: "quote",
+        format: "png",
+        backgroundColor: validColors[color],
+        width: 512,
+        height: 768,
+        scale: 2,
+        messages: [{
+            entities: [],
+            avatar: true,
+            from: {
+                id: 1,
+                name: name,
+                photo: { url: ppUrl }
+            },
+            text: text,
+            replyMessage: {}
+        }]
+    };
+
+    await sock.sendMessage(from, { react: { text: '💬', key: msg.key } });
+
+    try {
+        const { data } = await axios.post('https://qc.botcahx.eu.org/generate', payload, {
+            headers: { 'Content-Type': 'application/json' }
+        });
+
+        if (!data.result?.image) {
+            throw new Error("La API no generó una imagen válida.");
+        }
+
+        const imageBuffer = Buffer.from(data.result.image, 'base64');
+
+        const sticker = new Sticker(imageBuffer, {
+            pack: config.botName || 'Bot',
+            author: config.ownerName || 'Jules',
+            type: StickerTypes.FULL,
+            quality: 70
+        });
+
+        const stickerMessage = await sticker.toMessage();
+        await sock.sendMessage(from, stickerMessage, { quoted: msg });
+        await sock.sendMessage(from, { react: { text: '✅', key: msg.key } });
+
+    } catch (error) {
+        console.error("Error en el comando qc:", error);
+        await sock.sendMessage(from, { react: { text: '❌', key: msg.key } });
+        await sock.sendMessage(from, { text: `🚨 Ocurrió un error al generar el sticker de cita. Detalles: ${error.message}` }, { quoted: msg });
+    }
+  }
+};
+
+export default qcCommand;

--- a/plugins/warn.js
+++ b/plugins/warn.js
@@ -43,13 +43,6 @@ const warnCommand = {
         return sock.sendMessage(from, { text: "No tienes permisos de administrador para usar este comando." }, { quoted: msg });
       }
 
-      // El bot debe ser admin para poder expulsar
-      const botJid = sock.user.id.split(':')[0] + '@s.whatsapp.net';
-      const botIsAdmin = metadata.participants.find(p => p.id === botJid)?.admin;
-       if (!botIsAdmin) {
-        return sock.sendMessage(from, { text: "Necesito ser administrador para poder aplicar advertencias y expulsar." }, { quoted: msg });
-      }
-
       const mentionedJid = msg.message?.extendedTextMessage?.contextInfo?.mentionedJid?.[0];
       const quotedUserJid = msg.message?.extendedTextMessage?.contextInfo?.participant;
       const userToWarn = mentionedJid || quotedUserJid;


### PR DESCRIPTION
This commit introduces a new command, modifies an existing one, and completely refactors another as per the user's request.

1.  **New `qc` Command:**
    - A new command `qc` has been added to `plugins/qc.js`.
    - It generates a "quote sticker" from a user's message or a replied-to message.
    - The command takes an optional color parameter and uses an external API (`https://qc.botcahx.eu.org/generate`) to create the quote image, which is then converted into a sticker.

2.  **`warn` Command Update:**
    - The `plugins/warn.js` command has been modified to remove the check that required the bot to have administrator privileges.
    - Group administrators can now use the `warn` command regardless of whether the bot itself is an admin.

3.  **`pinterest` Command Refactor:**
    - The `plugins/pinterest.js` command has been completely rewritten from scratch.
    - It now uses a new API endpoint (`https://api.platform.web.id/pinterest`) as specified.
    - The command now supports an optional numerical argument to define how many images to fetch (e.g., `.pin Gura 5`).
    - The logic has been updated to send images individually instead of as an album.
    - It includes an HTTPS agent to ignore SSL certificate errors, making the connection more robust.