### PR TITLE
feat: Add brat command for custom text stickers

### DIFF
--- a/plugins/brat.js
+++ b/plugins/brat.js
@@ -1,0 +1,49 @@
+import axios from 'axios';
+import StickerFormatter from 'wa-sticker-formatter';
+const { Sticker, StickerTypes } = StickerFormatter;
+
+const bratCommand = {
+  name: "brat",
+  category: "sticker",
+  description: "Crea un sticker con un texto y un estilo particular.",
+  aliases: [],
+
+  async execute({ sock, msg, text, usedPrefix, command, config }) {
+    const from = msg.key.remoteJid;
+    const inputText = text || msg.message?.extendedTextMessage?.contextInfo?.quotedMessage?.conversation || '';
+
+    if (!inputText.trim()) {
+      return sock.sendMessage(from, { text: `❌ Por favor, proporciona un texto.\n\n*Ejemplo:*\n*${usedPrefix + command}* Hola Mundo` }, { quoted: msg });
+    }
+
+    await sock.sendMessage(from, { react: { text: '⏳', key: msg.key } });
+
+    try {
+      const apiUrl = `https://api.yupra.my.id/api/image/brat?text=${encodeURIComponent(inputText)}`;
+      const response = await axios.get(apiUrl, { responseType: 'arraybuffer' });
+      const imageBuffer = Buffer.from(response.data, 'binary');
+
+      if (!imageBuffer) {
+        throw new Error("La API no devolvió una imagen válida.");
+      }
+
+      const sticker = new Sticker(imageBuffer, {
+        pack: config.botName || 'Yupra',
+        author: config.ownerName || 'Brat',
+        type: StickerTypes.FULL,
+        quality: 80
+      });
+
+      const stickerMessage = await sticker.toMessage();
+      await sock.sendMessage(from, stickerMessage, { quoted: msg });
+      await sock.sendMessage(from, { react: { text: '✅', key: msg.key } });
+
+    } catch (error) {
+      console.error("Error en el comando 'brat':", error);
+      await sock.sendMessage(from, { react: { text: '❌', key: msg.key } });
+      await sock.sendMessage(from, { text: `Gagal membuat sticker: ${error.message}` }, { quoted: msg });
+    }
+  }
+};
+
+export default bratCommand;


### PR DESCRIPTION
This commit introduces a new command, `brat`, which allows users to create custom stickers from a given text string.

- **New Command:** `plugins/brat.js` has been created based on the user's provided code sample.
- **API Integration:** The command utilizes the `https://api.yupra.my.id/api/image/brat` endpoint to generate a stylized image from the user's text.
- **Sticker Generation:** The resulting image is then converted into a full-size WhatsApp sticker using the `wa-sticker-formatter` library. The sticker's pack name and author are automatically populated from the bot's main `config.js` file.
- **Error Handling:** The command includes checks for empty input and handles potential API failures gracefully, informing the user if an error occurs during the process.